### PR TITLE
User change password

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/admin/request/ChangePasswordRequest.java
+++ b/src/main/java/com/dominest/dominestbackend/api/admin/request/ChangePasswordRequest.java
@@ -1,4 +1,4 @@
-package com.dominest.dominestbackend.domain.email.request;
+package com.dominest.dominestbackend.api.admin.request;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -8,10 +8,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class EmailRequest {
-    private String email;
+public class ChangePasswordRequest {
 
-    private String code;
+    private String password;
 
     private String newPassword;
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/email/controller/EmailController.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/email/controller/EmailController.java
@@ -3,7 +3,6 @@ package com.dominest.dominestbackend.domain.email.controller;
 import com.dominest.dominestbackend.domain.email.request.EmailRequest;
 import com.dominest.dominestbackend.domain.email.service.EmailService;
 import com.dominest.dominestbackend.domain.email.service.EmailVerificationService;
-import com.dominest.dominestbackend.domain.user.service.UserService;
 import com.dominest.dominestbackend.global.apiResponse.ApiResponseDto;
 import com.dominest.dominestbackend.global.apiResponse.ErrorStatus;
 import com.dominest.dominestbackend.global.apiResponse.SuccessStatus;
@@ -12,33 +11,26 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/email")
 public class EmailController {
     private final EmailService emailService;
 
-    private final UserService userService;
-
     private final EmailVerificationService emailVerificationService;
 
     @PostMapping("/send") // 인증번호 발송 버튼 누르면 메일 가게
-    public ResponseEntity<ApiResponseDto<String>> mailConfirm(@RequestBody EmailRequest emailRequest) throws Exception{
-        emailService.sendSimpleMessage(emailRequest.getEmail()); // 이메일로 인증코드를 보낸다.
+    public ResponseEntity<ApiResponseDto<String>> sendEmail(@RequestBody EmailRequest emailRequest) throws Exception {
+        emailService.sendJoinMessage(emailRequest.getEmail()); // 이메일로 인증코드를 보낸다.
         return ResponseEntity.ok(ApiResponseDto.success(SuccessStatus.SEND_EMAIL_SUCCESS, emailRequest.getEmail() + "로 검증코드를 전송했습니다."));
     }
 
-//    @PostMapping("/verify/code") // 이메일 인증코드 검증
-//    public ResponseEntity<ApiResponseDto<String>> verifyEmail(@RequestBody CodeRequest request) {
-//        session.setMaxInactiveInterval(30 * 60);
-//        String sessionCode = (String) session.getAttribute("emailCode");
-//        if (sessionCode != null && sessionCode.equals(request.getCode())) { // 인증 성공
-//            return ResponseEntity.ok(ApiResponseDto.success(SuccessStatus.VERIFY_EMAIL_SUCCESS)); // 이메일과 함께 성공 응답 반환
-//        } else {
-//            // 인증 실패
-//            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponseDto.error(ErrorStatus.VERIFY_EMAIL_FAILED)); // 400 Bad Request 상태로 실패 응답 반환
-//        }
-//    }
+    @PostMapping("/change/password") // 임시 비밀번호 이메일 전송
+    public ResponseEntity<ApiResponseDto<String>> changePasswordEmail(@RequestBody EmailRequest emailRequest) throws Exception {
+        emailService.sendChangeMessage(emailRequest.getEmail()); // 이메일로 인증코드를 보냄
+        return ResponseEntity.ok(ApiResponseDto.success(SuccessStatus.SEND_EMAIL_SUCCESS, emailRequest.getEmail() + "로 검증코드를 전송했습니다."));
+    }
 
     @PostMapping("/verify/code") // 이메일 인증코드 검증
     public ResponseEntity<ApiResponseDto<String>> verifyEmail(@RequestBody EmailRequest emailRequest) {

--- a/src/main/java/com/dominest/dominestbackend/domain/email/service/EmailService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/email/service/EmailService.java
@@ -1,14 +1,19 @@
 package com.dominest.dominestbackend.domain.email.service;
 
+import com.dominest.dominestbackend.domain.user.User;
+import com.dominest.dominestbackend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
+import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,36 +21,16 @@ public class EmailService {
     private final JavaMailSender emailsender; // Bean 등록해둔 MailConfig 를 emailsender 라는 이름으로 autowired
 
     private final EmailVerificationService emailVerificationService;
-    private String authNum; // 인증번호
 
-    //랜덤 인증 코드 생성
-//    public void createCode() {
-//        Random random = new Random();
-//        StringBuffer key = new StringBuffer();
-//
-//        for(int i=0;i<8;i++) {
-//            int index = random.nextInt(3);
-//
-//            switch (index) {
-//                case 0 :
-//                    key.append((char) ((int)random.nextInt(26) + 97));
-//                    break;
-//                case 1:
-//                    key.append((char) ((int)random.nextInt(26) + 65));
-//                    break;
-//                case 2:
-//                    key.append(random.nextInt(9));
-//                    break;
-//            }
-//        }
-//        authNum = key.toString();
-//    }
+    private final UserRepository userRepository;
 
-    // 메일 양식 작성
-    public MimeMessage createMessage(String email) throws MessagingException{
-        authNum = emailVerificationService.generateCode(email);
+    private final PasswordEncoder passwordEncoder;
+
+
+    // 회원가입 메일 양식 작성
+    private MimeMessage createJoinMessage(String email) throws MessagingException{
+        String authNum = emailVerificationService.generateCode(email);
         String setFrom = "gjwldud0719@naver.com";
-        String toEmail = email;
         String title = "회원가입 인증 번호";
 
         MimeMessage message = emailsender.createMimeMessage();
@@ -85,23 +70,82 @@ public class EmailService {
         n += "</div>";
         n += "</div>";
 
-
         message.setText(n,"utf-8", "html");
         return message;
     }
 
+    private MimeMessage createChangeMessage(String email) throws MessagingException { // 임시 비밀번호 발송 메일 만들기
+        String authNum = emailVerificationService.generateCode(email);
 
-    // 메일 발송
-    public String sendSimpleMessage(String email) throws Exception{
-        MimeMessage message = createMessage(email); // 메일 발송
+        Optional<User> user = userRepository.findByEmail(email);
+
+        if(user.isPresent()){
+            User foundUser = user.get();
+            foundUser.changePassword(passwordEncoder.encode(authNum));
+            userRepository.save(foundUser);
+        }
+
+        String setFrom = "gjwldud0719@naver.com";
+        String title = "임시 비밀번호";
+
+        MimeMessage message = emailsender.createMimeMessage();
+        message.addRecipients(MimeMessage.RecipientType.TO, email); // 보내는 대상
+        message.setSubject(title);
+        message.setFrom(setFrom);
+        String n = "";
+        n += "<div style='display: flex; width: 100%; min-height: 100%; text-align: center; justify-content: center; background-color: #f0f0f0;'>";
+        n += "<div style='display: flex; width: 80%; padding-top: 5%; background-color: white; text-align: left; justify-content: center;'>";
+        n += "<div style='width: 90%; background-color: white; text-align: left;'>";
+        n += "<h1 style='color: black; text-align: center;'>Dominest 임시 비밀번호 안내</h1>";
+        n += "<br />";
+        n += "<p style='text-align: center;'><strong style='color: #444444;'>\"임시 비밀번호\"</strong></p>";
+        n += "<p style='text-align: center;'>아래에 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해 주세요.</p>";
+        n += "<br />";
+        n += "<hr />";
+        n += "<p style='text-align: center;'>인증번호: <strong style='letter-spacing: 5px; color: blue;'>" + authNum + "</strong></p>";
+        n += "<br />";
+        n += "<br />";
+        n += "<br />";
+        n += "<br />";
+        n += "<br />";
+        n += "<br />";
+        n += "<br />";
+        n += "<br />";
+        n += "<hr />";
+        n += "<div style='position: fixed; bottom: 0; width: 71%; background-color: #f0f0f0;'>";
+        n += "<p style='line-height: 13px; text-align: center; font-size: 12px;'>본 메일은 발신 전용입니다.</p>";
+        n += "<p style='line-height: 13px; text-align: center; font-size: 12px;'>궁금하신 사항은 기숙사 행정실에 문의 바랍니다.</p>";
+        n += "<p style='line-height: 13px; text-align: center; font-size: 12px;'>성공회대 IT 도미도미 팀 제작</p>";
+        n += "<p style='line-height: 13px; text-align: center; font-size: 12px;'>사업자 등록 이후 추가할 예정</p>";
+        n += "<p style='line-height: 13px; text-align: center; font-size: 12px;'>전화: 010-8408-9384 이메일: zzxx373014@gmail.com</p>";
+        n += "<hr />";
+        n += "</div>";
+        n += "</div>";
+        n += "</div>";
+        n += "</div>";
+
+        message.setText(n, "utf-8", "html");
+        return message;
+    }
+
+
+    public void sendJoinMessage(String email) throws Exception{ // 회원가입 메일 발송
+        MimeMessage message = createJoinMessage(email);
         try{
             emailsender.send((message));
         } catch(MailException es){
             es.printStackTrace();
             throw new IllegalArgumentException();
         }
-        return authNum; // 메일로 보냈던 인증 코드를 서버로 반환
     }
 
-
+    public void sendChangeMessage(String email) throws Exception{ // 임시 비밀번호
+        MimeMessage message = createChangeMessage(email);
+        try{
+            emailsender.send((message));
+        } catch(MailException es){
+            es.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+    }
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/email/service/EmailVerificationService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/email/service/EmailVerificationService.java
@@ -16,7 +16,6 @@ public class EmailVerificationService {
     @Getter
     private final Cache<String, String> codeExpirationCache; // <email, verification code>. thread-safe map.
     private final Cache<String, Boolean> emailVerificationStatusCache; // <email, verification status>. thread-safe map.
-    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
     @Autowired
     public EmailVerificationService() {
@@ -34,15 +33,7 @@ public class EmailVerificationService {
         String verificationCode = UUID.randomUUID().toString().substring(0, 4);
         codeExpirationCache.put(email, verificationCode);
 
-        // 20분 후에 캐시에서 삭제. 검증코드는 20분간 유효
-        executorService.schedule(() -> invalidateCode(email), 20, TimeUnit.MINUTES);
         return verificationCode;
-    }
-
-    // fixme: expireAfterWrite 와 기능이 겹치는지 확인
-    private void invalidateCode(String email) {
-        // Discards any cached value for the key.
-        codeExpirationCache.invalidate(email);
     }
 
     public boolean verifyCode(String email, String verificationCode) {

--- a/src/main/java/com/dominest/dominestbackend/domain/jwt/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/jwt/service/UserDetailsServiceImpl.java
@@ -1,0 +1,41 @@
+package com.dominest.dominestbackend.domain.jwt.service;
+
+import com.dominest.dominestbackend.domain.role.Role;
+import com.dominest.dominestbackend.domain.user.User;
+import com.dominest.dominestbackend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // 사용자 정보를 이메일로 조회
+        Optional<User> userOptional = userRepository.findByEmail(email);
+
+        if (userOptional.isEmpty()) {
+            throw new UsernameNotFoundException("해당 이메일을 가진 사용자를 찾을 수 없습니다.");
+        }
+
+        User user = userOptional.get();
+
+        // Spring Security의 UserDetails로 변환하여 반환
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                user.getAuthorities()
+        );
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/role/Role.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/role/Role.java
@@ -1,6 +1,8 @@
 package com.dominest.dominestbackend.domain.role;
 
-public enum Role {
+import org.springframework.security.core.GrantedAuthority;
+
+public enum Role implements GrantedAuthority {
     ROLE_USER("ROLE_USER"),
     ROLE_ADMIN("ROLE_ADMIN");
 
@@ -11,6 +13,11 @@ public enum Role {
     }
 
     public String getRole() {
+        return role;
+    }
+
+    @Override
+    public String getAuthority() {
         return role;
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/user/User.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/user/User.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -36,7 +38,9 @@ public class User implements UserDetails {
 //        this.isLogin = isLogin;
 //    }
 
-
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -57,7 +61,8 @@ public class User implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.roles.stream()
                 .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());    }
+                .collect(Collectors.toList());
+    }
 
     @Override
     public String getUsername() {

--- a/src/main/java/com/dominest/dominestbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.dominest.dominestbackend.domain.jwt.dto.TokenDto;
 import com.dominest.dominestbackend.domain.jwt.service.TokenManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
 
@@ -44,7 +46,12 @@ public class UserService {
         return tokenDto;
     }
 
+
     public boolean checkDuplicateEmail(String email){
         return userRepository.findByEmail(email).isPresent();
+    }
+
+    public boolean validateUserPassword(String currentPassword, String loggedInUserPassword) {
+        return passwordEncoder.matches(currentPassword, loggedInUserPassword);
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/global/apiResponse/ErrorStatus.java
+++ b/src/main/java/com/dominest/dominestbackend/global/apiResponse/ErrorStatus.java
@@ -20,6 +20,8 @@ public enum ErrorStatus {
 
 
     VERIFY_EMAIL_FAILED(HttpStatus.BAD_REQUEST, "이메일 인증 실패"),
+
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "인증되지 않은 이메일입니다."),
     USER_CERTIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "해당 아이디나 비밀번호를 가진 유저가 존재하지 않습니다."),
     USER_NOT_JOIN(HttpStatus.FORBIDDEN, "해당 사용자가 존재하지 않습니다."),
 

--- a/src/main/java/com/dominest/dominestbackend/global/apiResponse/ErrorStatus.java
+++ b/src/main/java/com/dominest/dominestbackend/global/apiResponse/ErrorStatus.java
@@ -14,10 +14,9 @@ public enum ErrorStatus {
      */
     VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     NOT_LOGIN_STATUS(HttpStatus.BAD_REQUEST, "로그인 되어있지 않습니다."),
+    INCORRECT_PASSWORD_ERROR(HttpStatus.BAD_REQUEST, "현재 비밀번호와 일치하지 않습니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-
-
 
     VERIFY_EMAIL_FAILED(HttpStatus.BAD_REQUEST, "이메일 인증 실패"),
 

--- a/src/main/java/com/dominest/dominestbackend/global/apiResponse/SuccessStatus.java
+++ b/src/main/java/com/dominest/dominestbackend/global/apiResponse/SuccessStatus.java
@@ -16,7 +16,8 @@ public enum SuccessStatus {
 
     VERIFY_EMAIL_SUCCESS(HttpStatus.OK, "이메일 인증 성공!"),
 
-    TOKEN_USER_INFO(HttpStatus.OK, "accessToken으로 유저 정보 가져오기 성공!!");
+    TOKEN_USER_INFO(HttpStatus.OK, "accessToken으로 유저 정보 가져오기 성공!!"),
+    CHANGE_PASSWORD_SUCCESS(HttpStatus.OK, "비밀번호 변경 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dominest/dominestbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/dominest/dominestbackend/global/config/SecurityConfig.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
-public class SecurityConfig{
+public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
@@ -36,6 +36,8 @@ public class SecurityConfig{
                 .antMatchers("/user/login").permitAll()
                 .antMatchers("/email/send").permitAll()
                 .antMatchers("/email/verify/code").permitAll()
+                // .antMatchers("/user/myPage/password").permitAll()
+                .antMatchers("/email/change/password").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
@@ -36,7 +36,6 @@ public enum ErrorCode {
     RESIDENT_NOT_FOUND(404, "해당 입사자가 존재하지 않습니다."),
     ;
 
-
     private int statusCode;
     private String message;
 
@@ -44,4 +43,5 @@ public enum ErrorCode {
         this.statusCode = status;
         this.message = message;
     }
+
 }


### PR DESCRIPTION
비밀번호 변경 관련 api 추가

1. /email/change/password : 임시 비밀번호 전송 api
2. /user/myPage/password : 마이페이지에서 비밀번호 변경 api

오류 / 성공 메세지는 시간날 때 한꺼번에 바꾸도록 하겠습니다~~

이메일 서비스의 createMessage에 바로 임시 비밀번호가 저장되는 코드가 있어 메소드의 역할에 맞지 않다는 생각이 들지만,,,
한번 방법을 생각해보도록 하겠습니당!!