### PR TITLE
즐겨찾기 여부를 포함하는 카테고리 조회

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
@@ -3,6 +3,7 @@ package com.dominest.dominestbackend.api.category.controller;
 import com.dominest.dominestbackend.api.category.request.CategoryCreateRequest;
 import com.dominest.dominestbackend.api.category.request.CategoryUpdateRequest;
 import com.dominest.dominestbackend.api.category.response.CategoryListDto;
+import com.dominest.dominestbackend.api.category.response.CategoryListWithFavoriteDto;
 import com.dominest.dominestbackend.api.common.ResTemplate;
 import com.dominest.dominestbackend.domain.post.component.category.Category;
 import com.dominest.dominestbackend.domain.post.component.category.repository.CategoryRepository;
@@ -13,25 +14,39 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/categories")
+@RequestMapping()
 public class CategoryController {
     private final CategoryService categoryService;
     private final CategoryRepository categoryRepository;
 
-    @GetMapping // 카테고리 조회
-    public ResTemplate<CategoryListDto> handleGetCategoryList() {
+    @GetMapping("/categories") // 카테고리 조회
+    public ResTemplate<CategoryListDto.Res> handleGetCategoryList() {
 
         List<Category> categories = categoryRepository.findAll();
-        CategoryListDto categoryDtoList = CategoryListDto.from(categories);
-        return new ResTemplate<>(HttpStatus.OK, "카테고리 조회 성공", categoryDtoList);
+        CategoryListDto.Res resDto = CategoryListDto.Res.from(categories);
+        return new ResTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
     }
 
-    @PostMapping // 카테고리 생성
+    // 현재 로그인한 사용자를 기준으로 즐겨찾기 여부와 함께 카테고리 조회
+    @GetMapping("/my-categories")
+    public ResTemplate<CategoryListWithFavoriteDto.Res> handleGetMyCategoryList(@NotNull(message = "인증 정보가 없습니다.") Principal principal) {
+        // 즐찾목록 다 조회해서 카테고리 ID들을 찾아낸다.
+        // 찾아낸 카테고리 ID들과 전체 카테고리 목록 중 일치하는 것들은 즐겨찾기가 되어있는 것이다.
+        List<Long> categoryIdsFromFavorites = categoryService.getIdAllByUserEmail(principal.getName());
+        List<Category> categories = categoryRepository.findAll();
+
+        CategoryListWithFavoriteDto.Res resDto = CategoryListWithFavoriteDto.Res.from(categories, categoryIdsFromFavorites);
+        return new ResTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
+    }
+
+    @PostMapping ("/categories")// 카테고리 생성
     public ResponseEntity<ResTemplate<?>> createCategory(@RequestBody @Valid final CategoryCreateRequest request) {
 
         Category category = categoryService.createCategory(request.getCategoryName(), request.getCategoryType(), request.getExplanation());
@@ -41,7 +56,7 @@ public class CategoryController {
                 .body(resTemplate);
     }
 
-    @PutMapping // 카테고리 수정
+    @PutMapping("/categories") // 카테고리 수정
     public ResTemplate<String> updateCategories(@RequestBody @Valid final List<CategoryUpdateRequest> requests) throws Exception {
 
         for (CategoryUpdateRequest request : requests) {
@@ -50,7 +65,7 @@ public class CategoryController {
         return new ResTemplate<>(HttpStatus.OK, "카테고리 수정 성공");
     }
 
-    @DeleteMapping("/{id}") // 카테고리 삭제
+    @DeleteMapping("/categories/{id}") // 카테고리 삭제
     public ResTemplate<String> deleteCategory(@PathVariable Long id) {
 
         categoryService.deleteCategoryById(id);

--- a/src/main/java/com/dominest/dominestbackend/api/category/response/CategoryListWithFavoriteDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/response/CategoryListWithFavoriteDto.java
@@ -9,13 +9,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 
-public class CategoryListDto {
+public class CategoryListWithFavoriteDto {
     @Getter
     public static class Res {
         List<CategoryDto> categories;
 
-        public static Res from(List<Category> categories){
-            return new Res(CategoryDto.from(categories));
+        public static Res from(List<Category> categories, List<Long> favoriteIds){
+            return new Res(CategoryDto.from(categories, favoriteIds));
         }
         Res(List<CategoryDto> categories){
             this.categories = categories;
@@ -26,21 +26,23 @@ public class CategoryListDto {
         private static class CategoryDto{
             Long id;
             String name; // 카테고리 이름
-            Type type;
-            String explanation; // 카테고리 상세설명
+            Type type;  // 타입
+            boolean favorite; // 즐겨찾기 여부
+            String categoryLink;
 
-            static CategoryDto from(Category category) {
+            static CategoryDto from(Category category, List<Long> favoriteIds) {
                 return CategoryDto.builder()
                         .id(category.getId())
                         .name(category.getName())
                         .type(category.getType())
-                        .explanation(category.getExplanation())
+                        .favorite(favoriteIds.contains(category.getId()))
+                        .categoryLink(category.getPostsLink())
                         .build();
             }
 
-            static List<CategoryDto> from(List<Category> categories) {
+            static List<CategoryDto> from(List<Category> categories, List<Long> favoriteIds) {
                 return categories.stream()
-                        .map(CategoryDto::from)
+                        .map(category -> CategoryDto.from(category, favoriteIds))
                         .collect(Collectors.toList());
             }
         }

--- a/src/main/java/com/dominest/dominestbackend/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/favorite/controller/FavoriteController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.constraints.NotNull;
 import java.security.Principal;
 
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class FavoriteController {
 
     // 토큰을 소유한 유저의 즐찾목록 전체 조회
     @GetMapping("/favorites")
-    public ResTemplate<?> handleGetAllFavorites(Principal principal) {
+    public ResTemplate<?> handleGetAllFavorites(@NotNull(message = "인증 정보가 없습니다.") Principal principal) {
         FavoriteListDto.Res resDto = favoriteService.getAllByUserEmail(principal.getName());
         return new ResTemplate<>(HttpStatus.OK, "즐겨찾기 목록 조회"
                 , resDto);

--- a/src/main/java/com/dominest/dominestbackend/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/favorite/controller/FavoriteController.java
@@ -3,6 +3,8 @@ package com.dominest.dominestbackend.api.favorite.controller;
 import com.dominest.dominestbackend.api.common.ResTemplate;
 import com.dominest.dominestbackend.api.favorite.dto.FavoriteListDto;
 import com.dominest.dominestbackend.domain.favorite.FavoriteService;
+import com.dominest.dominestbackend.domain.post.component.category.repository.CategoryRepository;
+import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +19,8 @@ import java.security.Principal;
 @RestController
 public class FavoriteController {
     private final FavoriteService favoriteService;
+    private final CategoryService categoryService;
+    private final CategoryRepository categoryRepository;
 
     // 즐겨찾기 추가 / 취소
     @PostMapping("/categories/{categoryId}/favorites")
@@ -34,3 +38,23 @@ public class FavoriteController {
                 , resDto);
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/dominest/dominestbackend/api/favorite/dto/FavoriteListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/favorite/dto/FavoriteListDto.java
@@ -16,7 +16,7 @@ public class FavoriteListDto {
             return new Res(FavoriteDto.from(favorites));
         }
 
-        public Res(List<FavoriteDto> favorites) {
+        Res(List<FavoriteDto> favorites) {
             this.favorites = favorites;
         }
 

--- a/src/main/java/com/dominest/dominestbackend/domain/favorite/Favorite.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/favorite/Favorite.java
@@ -27,6 +27,12 @@ public class Favorite extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    /*
+    * 즐겨찾기 상태를 boolean으로 표현한다.
+    * Favorite 객체가 있으면 TRUE, 없으면 FALSE 취급할 수도 있겠으나,
+    * 잦은 즐겨찾기 추가/취소에 대한 DB 부하를 줄이기 위해 boolean으로 표현한다.
+    * 이로써 FavoriteService.addOrUndo() 메서드에서 즐겨찾기 객체가 없으면 새로 생성하고, 있으면 상태를 바꿀 수 있다.
+    * */
     @Column(nullable = false)
     private boolean onOff;  // 즐겨찾기 상태
 

--- a/src/main/java/com/dominest/dominestbackend/domain/favorite/FavoriteRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/favorite/FavoriteRepository.java
@@ -16,7 +16,7 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @Query("SELECT f FROM Favorite f" +
             " JOIN FETCH f.category c" +
             " JOIN f.user u" +
-            " WHERE u.email = :email")
+            " WHERE u.email = :email AND f.onOff = true")
     // userEmail은 조회결과가 아니라 조건이므로 Fetch하지 않아도 될 듯?
     List<Favorite> findAllByUserEmailFetchCategory(@Param("email") String email);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/repository/CategoryRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/repository/CategoryRepository.java
@@ -2,6 +2,16 @@ package com.dominest.dominestbackend.domain.post.component.category.repository;
 
 import com.dominest.dominestbackend.domain.post.component.category.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    @Query("SELECT f.category.id FROM Favorite f" +
+            " JOIN  f.category c" +
+            " JOIN f.user u" +
+            " WHERE u.email = :email AND f.onOff = true")
+        // userEmail은 조회결과가 아니라 조건이므로 Fetch하지 않아도 될 듯?
+    List<Long> findIdAllByUserEmailFetchCategory(@Param("email") String email);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/service/CategoryService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/service/CategoryService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -75,8 +76,34 @@ public class CategoryService {
         return EntityUtil.checkNotFound(categoryRepository.findById(categoryId), ErrorCode.CATEGORY_NOT_FOUND);
     }
 
+    public List<Long> getIdAllByUserEmail(String email) {
+        // Favorite 되어있는 카테고리 ID 전체 조회
+        return categoryRepository.findIdAllByUserEmailFetchCategory(email);
+    }
+
     @Transactional
     public void deleteCategoryById(Long categoryId) {
         categoryRepository.deleteById(categoryId);
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/dominest/dominestbackend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dominest/dominestbackend/global/config/security/SecurityConfig.java
@@ -37,7 +37,11 @@ public class SecurityConfig {
                 .and()
 
                 .authorizeRequests()
-                .antMatchers(HttpMethod.GET).permitAll() // GET 요청은 토큰 검증 예외
+                /*
+                permitAll()은 필터링 예외가 아니라, 필터링을 모두 거치고 나서 Auth 객체가 없어도 접근을 허용하는 것이다.
+                그래서 GET 요청에서도 SecurityContext의 Authentication 객체를 활용 가능하다. 물론 해당 객체는 null일 수도 있다.
+                */
+                .antMatchers(HttpMethod.GET).permitAll() // GET 요청은 핕터링
                 .antMatchers(HttpMethod.OPTIONS).permitAll() // OPTIONS 요청은 토큰 검증 예외
                 .antMatchers("/user/join").permitAll() // 회원가입 요청은 토큰 검증 예외
                 .antMatchers("/user/login").permitAll()


### PR DESCRIPTION
카테고리 조회 시 즐찾여부와 조회링크를 포함하는
[GET] "/my-categories" 를 추가

---

버그수정: 
즐찾목록 조회시 모든 카테고리 출력 -> 즐찾 활성화된 데이터만을 조회하도록 변경