### PR TITLE
민원 등록, 수정, 삭제, 전체조회

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/admin/controller/UserController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/admin/controller/UserController.java
@@ -4,7 +4,7 @@ import com.dominest.dominestbackend.api.admin.request.ChangePasswordRequest;
 import com.dominest.dominestbackend.api.admin.request.JoinRequest;
 import com.dominest.dominestbackend.api.admin.request.LoginRequest;
 import com.dominest.dominestbackend.api.admin.response.JoinResponse;
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.domain.email.service.EmailVerificationService;
 import com.dominest.dominestbackend.domain.jwt.dto.TokenDto;
 import com.dominest.dominestbackend.domain.jwt.service.TokenManager;
@@ -58,26 +58,26 @@ public class UserController {
     }
 
     @PostMapping("/login") // 로그인
-    public ResTemplate<TokenDto> login(@RequestBody @Valid final LoginRequest request) {
+    public RspTemplate<TokenDto> login(@RequestBody @Valid final LoginRequest request) {
         TokenDto tokenDto = userService.loginTemp(request.getEmail(), request.getPassword());
 
-        return new ResTemplate<>(HttpStatus.OK, "로그인 성공", tokenDto);
+        return new RspTemplate<>(HttpStatus.OK, "로그인 성공", tokenDto);
     }
 
     @PostMapping("/login/short-token-exp") // 로그인
-    public ResTemplate<TokenDto> loginV2(@RequestBody @Valid final LoginRequest request) {
+    public RspTemplate<TokenDto> loginV2(@RequestBody @Valid final LoginRequest request) {
         TokenDto tokenDto = userService.login(request.getEmail(), request.getPassword());
 
-        return new ResTemplate<>(HttpStatus.OK, "로그인 성공", tokenDto);
+        return new RspTemplate<>(HttpStatus.OK, "로그인 성공", tokenDto);
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResTemplate<Void> logout(Principal principal) {
+    public RspTemplate<Void> logout(Principal principal) {
         // 액세스 토큰 검증은 필터에서 거치므로 바로 로그아웃 처리
         userService.logout(PrincipalUtil.toEmail(principal));
 
-        return new ResTemplate<>(HttpStatus.OK, "로그아웃 성공");
+        return new RspTemplate<>(HttpStatus.OK, "로그아웃 성공");
     }
 
 
@@ -86,7 +86,7 @@ public class UserController {
      *   refresh 토큰을 이용, access 토큰을 재발급하는 메소드
      */
     @PostMapping(value = "/token/reissue")
-    public ResTemplate<TokenDto> accessToken(HttpServletRequest httpServletRequest){
+    public RspTemplate<TokenDto> accessToken(HttpServletRequest httpServletRequest){
 
         String authorizationHeader = httpServletRequest.getHeader("Authorization");
 
@@ -95,7 +95,7 @@ public class UserController {
         String refreshToken = authorizationHeader.split(" ")[1];
         TokenDto tokenDto = userService.reassureByRefreshToken(refreshToken);
 
-        return new ResTemplate<>(HttpStatus.OK, "토큰 재발급", tokenDto);
+        return new RspTemplate<>(HttpStatus.OK, "토큰 재발급", tokenDto);
     }
 
     @GetMapping("/login-test") // accesstoken으로 유저정보 가져오기

--- a/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
@@ -4,7 +4,7 @@ import com.dominest.dominestbackend.api.category.request.CategoryCreateRequest;
 import com.dominest.dominestbackend.api.category.request.CategoryUpdateRequest;
 import com.dominest.dominestbackend.api.category.response.CategoryListDto;
 import com.dominest.dominestbackend.api.category.response.CategoryListWithFavoriteDto;
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.domain.post.component.category.Category;
 import com.dominest.dominestbackend.domain.post.component.category.repository.CategoryRepository;
 import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
@@ -28,48 +28,48 @@ public class CategoryController {
     private final CategoryRepository categoryRepository;
 
     @GetMapping("/categories") // 카테고리 조회
-    public ResTemplate<CategoryListDto.Res> handleGetCategoryList() {
+    public RspTemplate<CategoryListDto.Res> handleGetCategoryList() {
 
         List<Category> categories = categoryRepository.findAll();
         CategoryListDto.Res resDto = CategoryListDto.Res.from(categories);
-        return new ResTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
+        return new RspTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
     }
 
     // 현재 로그인한 사용자를 기준으로 즐겨찾기 여부와 함께 카테고리 조회
     @GetMapping("/my-categories")
-    public ResTemplate<CategoryListWithFavoriteDto.Res> handleGetMyCategoryList(@NotNull(message = "인증 정보가 없습니다.") Principal principal) {
+    public RspTemplate<CategoryListWithFavoriteDto.Res> handleGetMyCategoryList(@NotNull(message = "인증 정보가 없습니다.") Principal principal) {
         // 즐찾목록 다 조회해서 카테고리 ID들을 찾아낸다.
         // 찾아낸 카테고리 ID들과 전체 카테고리 목록 중 일치하는 것들은 즐겨찾기가 되어있는 것이다.
         List<Long> categoryIdsFromFavorites = categoryService.getIdAllByUserEmail(PrincipalUtil.toEmail(principal));
         List<Category> categories = categoryRepository.findAll();
 
         CategoryListWithFavoriteDto.Res resDto = CategoryListWithFavoriteDto.Res.from(categories, categoryIdsFromFavorites);
-        return new ResTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
+        return new RspTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
     }
 
     @PostMapping ("/categories")// 카테고리 생성
-    public ResponseEntity<ResTemplate<Void>> createCategory(@RequestBody @Valid final CategoryCreateRequest request) {
+    public ResponseEntity<RspTemplate<Void>> createCategory(@RequestBody @Valid final CategoryCreateRequest request) {
 
         Category category = categoryService.create(request.getCategoryName(), request.getCategoryType(), request.getExplanation());
-        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED, "카테고리 생성 성공");
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, "카테고리 생성 성공");
         return ResponseEntity
                 .created(URI.create("/categories/" + category.getId()))
-                .body(resTemplate);
+                .body(rspTemplate);
     }
 
     @PutMapping("/categories") // 카테고리 수정
-    public ResTemplate<String> updateCategories(@RequestBody @Valid final List<CategoryUpdateRequest> requests) throws Exception {
+    public RspTemplate<String> updateCategories(@RequestBody @Valid final List<CategoryUpdateRequest> requests) throws Exception {
 
         for (CategoryUpdateRequest request : requests) {
             categoryService.update(request.getId(), request.getCategoryName());
         }
-        return new ResTemplate<>(HttpStatus.OK, "카테고리 수정 성공");
+        return new RspTemplate<>(HttpStatus.OK, "카테고리 수정 성공");
     }
 
     @DeleteMapping("/categories/{id}") // 카테고리 삭제
-    public ResTemplate<String> deleteCategory(@PathVariable Long id) {
+    public RspTemplate<String> deleteCategory(@PathVariable Long id) {
 
         categoryService.deleteById(id);
-        return new ResTemplate<>(HttpStatus.OK, id +"번 카테고리 삭제 성공");
+        return new RspTemplate<>(HttpStatus.OK, id +"번 카테고리 삭제 성공");
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/api/common/AuditLog.java
+++ b/src/main/java/com/dominest/dominestbackend/api/common/AuditLog.java
@@ -1,0 +1,30 @@
+package com.dominest.dominestbackend.api.common;
+
+import com.dominest.dominestbackend.domain.common.BaseEntity;
+import com.dominest.dominestbackend.global.util.PrincipalUtil;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class AuditLog {
+    String createdBy;
+    String lastModifiedBy;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    LocalDateTime createTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    LocalDateTime lastModifiedTime;
+
+    public static AuditLog from(BaseEntity baseEntity){
+        return AuditLog.builder()
+                .createdBy(PrincipalUtil.strToName(baseEntity.getCreatedBy()))
+                .lastModifiedBy(PrincipalUtil.strToName(baseEntity.getLastModifiedBy()))
+                .createTime(baseEntity.getCreateTime())
+                .lastModifiedTime(baseEntity.getLastModifiedTime())
+                .build();
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/common/RspTemplate.java
+++ b/src/main/java/com/dominest/dominestbackend/api/common/RspTemplate.java
@@ -5,18 +5,18 @@ import org.springframework.http.HttpStatus;
 
 // 응답 템플릿
 @Getter
-public class ResTemplate<T> {
+public class RspTemplate<T> {
     int statusCode;
     String message;
     T data;
 
-    public ResTemplate(HttpStatus httpStatus, String message, T data) {
+    public RspTemplate(HttpStatus httpStatus, String message, T data) {
         this.statusCode = httpStatus.value();
         this.message = message;
         this.data = data;
     }
 
-    public ResTemplate(HttpStatus httpStatus, String message) {
+    public RspTemplate(HttpStatus httpStatus, String message) {
         this.statusCode = httpStatus.value();
         this.message = message;
     }

--- a/src/main/java/com/dominest/dominestbackend/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/favorite/controller/FavoriteController.java
@@ -1,6 +1,6 @@
 package com.dominest.dominestbackend.api.favorite.controller;
 
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.api.favorite.dto.FavoriteListDto;
 import com.dominest.dominestbackend.domain.favorite.Favorite;
 import com.dominest.dominestbackend.domain.favorite.FavoriteService;
@@ -24,23 +24,23 @@ public class FavoriteController {
 
     // 즐겨찾기 추가 / 취소
     @PostMapping("/categories/{categoryId}/favorites")
-    public ResTemplate<String>  handleAddOrUndoFavorite(@PathVariable Long categoryId, Principal principal) {
+    public RspTemplate<String> handleAddOrUndoFavorite(@PathVariable Long categoryId, Principal principal) {
 
         boolean isOn = favoriteService.addOrUndo(categoryId, PrincipalUtil.toEmail(principal));
 
         String resMsg = isOn ? "즐겨찾기 추가" : "즐겨찾기 취소";
-        return new ResTemplate<>(HttpStatus.OK, resMsg);
+        return new RspTemplate<>(HttpStatus.OK, resMsg);
     }
 
     // 토큰을 소유한 유저의 즐찾목록 전체 조회
     @GetMapping("/favorites")
-    public ResTemplate<FavoriteListDto.Res> handleGetAllFavorites(@NotNull(message = "인증 정보가 없습니다.") Principal principal) {
+    public RspTemplate<FavoriteListDto.Res> handleGetAllFavorites(@NotNull(message = "인증 정보가 없습니다.") Principal principal) {
 
         Sort sort = Sort.by(Sort.Direction.DESC, "lastModifiedTime");
         List<Favorite> favorites = favoriteService.getAllByUserEmail(PrincipalUtil.toEmail(principal), sort);
 
         FavoriteListDto.Res resDto = FavoriteListDto.Res.from(favorites);
-        return new ResTemplate<>(HttpStatus.OK, "즐겨찾기 목록 조회"
+        return new RspTemplate<>(HttpStatus.OK, "즐겨찾기 목록 조회"
                 , resDto);
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
@@ -1,6 +1,6 @@
 package com.dominest.dominestbackend.api.post.complaint.controller;
 
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.api.post.complaint.dto.CreateComplaintDto;
 import com.dominest.dominestbackend.api.post.complaint.dto.UpdateComplaintDto;
 import com.dominest.dominestbackend.domain.post.complaint.ComplaintService;
@@ -21,38 +21,38 @@ public class ComplaintController {
 
     // 민원 등록
     @PostMapping("/categories/{categoryId}/posts/complaint")
-    public ResponseEntity<ResTemplate<Void>> handleCreateComplaint(
+    public ResponseEntity<RspTemplate<Void>> handleCreateComplaint(
             @RequestBody CreateComplaintDto.Req reqDto
             , @PathVariable Long categoryId, Principal principal
     ) {
         String email = PrincipalUtil.toEmail(principal);
         long complaintId = complaintService.create(reqDto, categoryId, email);
-        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED, complaintId + "번 민원 작성");
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, complaintId + "번 민원 작성");
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(resTemplate);
+                .body(rspTemplate);
     }
 
     // 민원 수정
     @PatchMapping("/complaints/{complaintId}")
-    public ResTemplate<Void> handleUpdateComplaint(
+    public RspTemplate<Void> handleUpdateComplaint(
             @PathVariable Long complaintId, @RequestBody UpdateComplaintDto.Req reqDto
     ) {
         // parcelId 조회, 값 바꿔치기, 저장하기
         long updatedId = complaintService.update(complaintId, reqDto);
 
-        return new ResTemplate<>(HttpStatus.OK, updatedId + "번 민원내역 수정");
+        return new RspTemplate<>(HttpStatus.OK, updatedId + "번 민원내역 수정");
     }
 
     // 민원 삭제
     @DeleteMapping("/complaints/{complaintId}")
-    public ResTemplate<Void> handleDeleteComplaint(
+    public RspTemplate<Void> handleDeleteComplaint(
             @PathVariable Long complaintId
     ) {
         long deleteId = complaintService.delete(complaintId);
 
-        return new ResTemplate<>(HttpStatus.OK, deleteId + "번 민원내역 삭제");
+        return new RspTemplate<>(HttpStatus.OK, deleteId + "번 민원내역 삭제");
     }
 }
 

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
@@ -2,16 +2,14 @@ package com.dominest.dominestbackend.api.post.complaint.controller;
 
 import com.dominest.dominestbackend.api.common.ResTemplate;
 import com.dominest.dominestbackend.api.post.complaint.dto.CreateComplaintDto;
+import com.dominest.dominestbackend.api.post.complaint.dto.UpdateComplaintDto;
 import com.dominest.dominestbackend.domain.post.complaint.ComplaintService;
 import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
 import com.dominest.dominestbackend.global.util.PrincipalUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -35,4 +33,42 @@ public class ComplaintController {
                 .status(HttpStatus.CREATED)
                 .body(resTemplate);
     }
+
+    // 민원 수정
+    @PatchMapping("/complaints/{complaintId}")
+    public ResTemplate<Void> handleUpdateComplaint(
+            @PathVariable Long complaintId, @RequestBody UpdateComplaintDto.Req reqDto
+    ) {
+        // parcelId 조회, 값 바꿔치기, 저장하기
+        long updatedId = complaintService.update(complaintId, reqDto);
+
+        return new ResTemplate<>(HttpStatus.OK, updatedId + "번 민원내역 수정");
+    }
+
+    // 민원 삭제
+    @DeleteMapping("/complaints/{complaintId}")
+    public ResTemplate<Void> handleDeleteComplaint(
+            @PathVariable Long complaintId
+    ) {
+        long deleteId = complaintService.delete(complaintId);
+
+        return new ResTemplate<>(HttpStatus.OK, deleteId + "번 민원내역 삭제");
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
@@ -1,0 +1,38 @@
+package com.dominest.dominestbackend.api.post.complaint.controller;
+
+import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.post.complaint.dto.CreateComplaintDto;
+import com.dominest.dominestbackend.domain.post.complaint.ComplaintService;
+import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
+import com.dominest.dominestbackend.global.util.PrincipalUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RequiredArgsConstructor
+@RestController
+public class ComplaintController {
+    private final ComplaintService complaintService;
+    private final CategoryService categoryService;
+
+    // 민원 등록
+    @PostMapping("/categories/{categoryId}/posts/complaint")
+    public ResponseEntity<ResTemplate<Void>> handleCreateComplaint(
+            @RequestBody CreateComplaintDto.Req reqDto
+            , @PathVariable Long categoryId, Principal principal
+    ) {
+        String email = PrincipalUtil.toEmail(principal);
+        long complaintId = complaintService.create(reqDto, categoryId, email);
+        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED, complaintId + "번 민원 작성");
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(resTemplate);
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/ComplaintListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/ComplaintListDto.java
@@ -1,0 +1,74 @@
+package com.dominest.dominestbackend.api.post.complaint.dto;
+
+import com.dominest.dominestbackend.api.common.AuditLog;
+import com.dominest.dominestbackend.api.common.CategoryDto;
+import com.dominest.dominestbackend.api.common.PageInfoDto;
+import com.dominest.dominestbackend.domain.post.complaint.Complaint;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ComplaintListDto {
+
+    @Getter
+    public static class Res {
+        CategoryDto category;
+        PageInfoDto page;
+
+        List<ComplaintDto> complaints;
+
+        public static Res from(Page<Complaint> complaintPage, Category category) {
+            CategoryDto categoryDto = CategoryDto.from(category);
+            PageInfoDto pageInfoDto = PageInfoDto.from(complaintPage);
+
+            List<ComplaintDto> complaints = ComplaintDto.from(complaintPage);
+            return new Res(categoryDto, pageInfoDto, complaints);
+        }
+
+        public Res(CategoryDto category, PageInfoDto page, List<ComplaintDto> complaints) {
+            this.category = category;
+            this.page = page;
+            this.complaints = complaints;
+        }
+
+    }
+
+    @Builder
+    @Getter
+    static class ComplaintDto {
+        Long id;
+        LocalDate date; // 민원접수일자
+        String roomNo; // 호실
+        String complaintCause; // 민원내역. FtIdx 만들어야 함.
+        String complaintResolution; // 민원처리내역. FtIdx 만들어야 함.
+        Complaint.ProcessState processState; // 처리상태
+
+        AuditLog auditLog;
+
+        static ComplaintDto from(Complaint complaint){
+            return ComplaintDto.builder()
+                    .id(complaint.getId())
+                    .date(complaint.getDate())
+                    .roomNo(complaint.getRoomNo())
+                    .complaintCause(complaint.getComplaintCause())
+                    .complaintResolution(complaint.getComplaintResolution())
+                    .processState(complaint.getProcessState())
+                    .auditLog(AuditLog.from(complaint))
+                    .build();
+        }
+
+        static List<ComplaintDto> from(Page<Complaint> complaints){
+            return complaints.stream()
+                    .map(ComplaintDto::from)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/CreateComplaintDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/CreateComplaintDto.java
@@ -1,0 +1,46 @@
+package com.dominest.dominestbackend.api.post.complaint.dto;
+
+import com.dominest.dominestbackend.domain.post.complaint.Complaint;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateComplaintDto {
+    @NoArgsConstructor
+    @Getter
+    public static class Req {
+        @NotBlank(message = "기숙사 방 번호를 입력해주세요.")
+        private String roomNo; // N호실
+
+        // 바인딩 실패 혹은 NULL 삽입 시 empty String으로 대체
+        private String complaintCause = ""; // 민원내역. FtIdx 만들어야 함.
+        // 바인딩 실패 혹은 NULL 삽입 시 empty String으로 대체
+        private String complaintResolution = ""; // 민원처리내역. FtIdx 만들어야 함.
+
+        @NotNull(message = "민원처리상태를 입력해주세요.")
+        private Complaint.ProcessState processState;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        @NotNull(message = "민원접수일자를 입력해주세요.")
+        private LocalDate date; // 민원접수일자
+
+        public Complaint toEntity(User user, Category category) {
+            return Complaint.builder()
+                    .roomNo(roomNo)
+                    .complaintCause(complaintCause)
+                    .complaintResolution(complaintResolution)
+                    .processState(processState)
+                    .date(date)
+                    .writer(user)
+                    .category(category)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/UpdateComplaintDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/UpdateComplaintDto.java
@@ -1,0 +1,36 @@
+package com.dominest.dominestbackend.api.post.complaint.dto;
+
+import com.dominest.dominestbackend.domain.post.complaint.Complaint;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateComplaintDto {
+    @NoArgsConstructor
+    @Getter
+    public static class Req {
+        @NotNull(message = "id는 비어있을 수 없습니다.")
+        @Positive(message = "id가 1보다 작습니다.")
+        private Long id;
+        @NotBlank(message = "기숙사 방 번호를 입력해주세요.")
+        private String roomNo; // N호실
+
+        // 바인딩 실패 혹은 NULL 삽입 시 empty String으로 대체
+        private String complaintCause = ""; // 민원내역. FtIdx 만들어야 함.
+        // 바인딩 실패 혹은 NULL 삽입 시 empty String으로 대체
+        private String complaintResolution = ""; // 민원처리내역. FtIdx 만들어야 함.
+
+        @NotNull(message = "민원처리상태를 입력해주세요.")
+        private Complaint.ProcessState processState;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        @NotNull(message = "민원접수일자를 입력해주세요.")
+        private LocalDate date; // 민원접수일자
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/image/controller/ImageTypeController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/image/controller/ImageTypeController.java
@@ -1,6 +1,6 @@
 package com.dominest.dominestbackend.api.post.image.controller;
 
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.api.post.image.dto.ImageTypeDetailDto;
 import com.dominest.dominestbackend.api.post.image.dto.ImageTypeListDto;
 import com.dominest.dominestbackend.api.post.image.dto.SaveImageTypeDto;
@@ -41,16 +41,16 @@ public class ImageTypeController {
     //  3. url 리스트
     // 이미지 게시물 작성
     @PostMapping("/categories/{categoryId}/posts/image-types")
-    public ResponseEntity<ResTemplate<Void>> handleCreateImageType(@Valid SaveImageTypeDto.Req reqDto
+    public ResponseEntity<RspTemplate<Void>> handleCreateImageType(@Valid SaveImageTypeDto.Req reqDto
                                                                                 , @PathVariable Long categoryId, Principal principal) {
         // 이미지 저장
         String email = PrincipalUtil.toEmail(principal);
         long imageTypeId = imageTypeService.create(reqDto, categoryId, email);
-        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED, imageTypeId + "번 게시글 작성");
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, imageTypeId + "번 게시글 작성");
 
         return ResponseEntity
                 .created(URI.create("/posts/image-types/" + imageTypeId))
-                .body(resTemplate);
+                .body(rspTemplate);
     }
 
     /**
@@ -59,23 +59,23 @@ public class ImageTypeController {
      *  최초 생성자 이름은 유지하지만, 수정 시 권한을 체크하지 않고 수정자 이름만 변경한다.
      */
     @PatchMapping("/posts/image-types/{imageTypeId}")
-    public ResTemplate<Void> handleUpdateImageType(@PathVariable Long imageTypeId
+    public RspTemplate<Void> handleUpdateImageType(@PathVariable Long imageTypeId
                                                                                         , @Valid SaveImageTypeDto.Req reqDto) {
         long updatedImageTypeId = imageTypeService.update(reqDto, imageTypeId);
-        return new ResTemplate<>(HttpStatus.OK, updatedImageTypeId + "번 게시글 수정");
+        return new RspTemplate<>(HttpStatus.OK, updatedImageTypeId + "번 게시글 수정");
     }
 
     /**
      *  게시글 삭제. 권한을 체크하지 않는다.
      */
     @DeleteMapping("/posts/image-types/{imageTypeId}")
-    public ResTemplate<Void> handleUpdateImageType(@PathVariable Long imageTypeId) {
+    public RspTemplate<Void> handleUpdateImageType(@PathVariable Long imageTypeId) {
         ImageType imageType = imageTypeService.deleteById(imageTypeId);
 
         List<String> imageUrlsToDelete = imageType.getImageUrls();
         fileService.deleteFile(FileService.FilePrefix.POST_IMAGE_TYPE, imageUrlsToDelete);
 
-        return new ResTemplate<>(HttpStatus.OK, imageType.getId() + "번 게시글 삭제");
+        return new RspTemplate<>(HttpStatus.OK, imageType.getId() + "번 게시글 삭제");
     }
 
     // 게시물 이미지 조회
@@ -94,20 +94,20 @@ public class ImageTypeController {
 
     // 게시물 단건 조회
     @GetMapping("/categories/{categoryId}/posts/image-types/{imageTypeId}")
-    public ResTemplate<ImageTypeDetailDto.Res> handleGetImageType(
+    public RspTemplate<ImageTypeDetailDto.Res> handleGetImageType(
             @PathVariable Long categoryId, @PathVariable Long imageTypeId
     ) {
         ImageType imageType = imageTypeService.getById(imageTypeId);
 
         ImageTypeDetailDto.Res resDto = ImageTypeDetailDto.Res.from(imageType);
-        return new ResTemplate<>(HttpStatus.OK
+        return new RspTemplate<>(HttpStatus.OK
                 , imageTypeId+"번 게시물  조회 성공"
                 , resDto);
     }
 
     // 게시물 목록을 조회한다.
     @GetMapping("/categories/{categoryId}/posts/image-types")
-    public ResTemplate<ImageTypeListDto.Res> handleGetImageTypes(@PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page) {
+    public RspTemplate<ImageTypeListDto.Res> handleGetImageTypes(@PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page) {
         final int IMAGE_TYPE_PAGE_SIZE = 20;
         Pageable pageable = PageableUtil.of(page, IMAGE_TYPE_PAGE_SIZE);
 
@@ -116,7 +116,7 @@ public class ImageTypeController {
         Page<ImageType> imageTypes = imageTypeService.getPage(categoryId, pageable);
 
         ImageTypeListDto.Res resDto = ImageTypeListDto.Res.from(imageTypes, category);
-        return new ResTemplate<>(HttpStatus.OK
+        return new RspTemplate<>(HttpStatus.OK
                 , "페이지 게시글 목록 조회 - " + resDto.getPage().getCurrentPage() + "페이지"
                 , resDto);
     }

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
@@ -16,6 +16,7 @@ import com.dominest.dominestbackend.global.util.PrincipalUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -50,10 +51,11 @@ public class UndeliveredParcelController {
             @PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page
     ) {
         final int IMAGE_TYPE_PAGE_SIZE = 20;
-        Pageable pageable = PageableUtil.of(page, IMAGE_TYPE_PAGE_SIZE);
+        Sort sort = Sort.by(Sort.Direction.DESC, "id");
+        Pageable pageable = PageableUtil.of(page, IMAGE_TYPE_PAGE_SIZE, sort);
 
         Category category = categoryService.validateCategoryType(categoryId, Type.UNDELIVERED_PARCEL_REGISTER);
-        Page<UndeliveredParcelPost> postsPage = undelivParcelPostService.getPage(categoryId, pageable);
+        Page<UndeliveredParcelPost> postsPage = undelivParcelPostService.getPage(category.getId(), pageable);
 
         UndelivParcelPostListDto.Res resDto = UndelivParcelPostListDto.Res.from(postsPage, category);
         return new RspTemplate<>(HttpStatus.OK

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
@@ -35,7 +35,6 @@ public class UndeliveredParcelController {
     public ResponseEntity<ResTemplate<Void>> handleCreateParcelPost(
             @PathVariable Long categoryId, Principal principal
     ) {
-        // 이미지 저장
         String email = PrincipalUtil.toEmail(principal);
         long unDeliParcelId = undelivParcelPostService.create(categoryId, email);
         ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED, unDeliParcelId + "번 게시글 작성");

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
@@ -1,6 +1,6 @@
 package com.dominest.dominestbackend.api.post.undeliveredparcel.controller;
 
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.api.post.undeliveredparcel.dto.CreateUndelivParcelDto;
 import com.dominest.dominestbackend.api.post.undeliveredparcel.dto.UndelivParcelPostDetailDto;
 import com.dominest.dominestbackend.api.post.undeliveredparcel.dto.UndelivParcelPostListDto;
@@ -32,21 +32,21 @@ public class UndeliveredParcelController {
 
     // 게시글 등록
     @PostMapping("/categories/{categoryId}/posts/undelivered-parcel")
-    public ResponseEntity<ResTemplate<Void>> handleCreateParcelPost(
+    public ResponseEntity<RspTemplate<Void>> handleCreateParcelPost(
             @PathVariable Long categoryId, Principal principal
     ) {
         String email = PrincipalUtil.toEmail(principal);
         long unDeliParcelId = undelivParcelPostService.create(categoryId, email);
-        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED, unDeliParcelId + "번 게시글 작성");
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, unDeliParcelId + "번 게시글 작성");
 
         return ResponseEntity
                 .created(URI.create("/categories/"+categoryId+"/posts/undelivered-parcel/" + unDeliParcelId))
-                .body(resTemplate);
+                .body(rspTemplate);
     }
 
     //  게시글 목록 조회
     @GetMapping("/categories/{categoryId}/posts/undelivered-parcel")
-    public ResTemplate<UndelivParcelPostListDto.Res> handleGetParcelPosts(
+    public RspTemplate<UndelivParcelPostListDto.Res> handleGetParcelPosts(
             @PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page
     ) {
         final int IMAGE_TYPE_PAGE_SIZE = 20;
@@ -56,64 +56,64 @@ public class UndeliveredParcelController {
         Page<UndeliveredParcelPost> postsPage = undelivParcelPostService.getPage(categoryId, pageable);
 
         UndelivParcelPostListDto.Res resDto = UndelivParcelPostListDto.Res.from(postsPage, category);
-        return new ResTemplate<>(HttpStatus.OK
+        return new RspTemplate<>(HttpStatus.OK
                 , "페이지 게시글 목록 조회 - " + resDto.getPage().getCurrentPage() + "페이지"
                 ,resDto);
     }
 
     // 게시글 삭제
     @DeleteMapping("/posts/undelivered-parcel/{undelivParcelPostId}")
-    public ResponseEntity<ResTemplate<Void>> handleDeleteParcelPost(
+    public ResponseEntity<RspTemplate<Void>> handleDeleteParcelPost(
             @PathVariable Long undelivParcelPostId
     ) {
         long deletedPostId = undelivParcelPostService.delete(undelivParcelPostId);
 
-        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.OK, deletedPostId + "번 게시글 삭제");
-        return ResponseEntity.ok(resTemplate);
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.OK, deletedPostId + "번 게시글 삭제");
+        return ResponseEntity.ok(rspTemplate);
     }
 
     // 게시글 내부 관리목록에 관리물품 등록
     @PostMapping("/posts/undelivered-parcel/{undelivParcelPostId}")
-    public ResponseEntity<ResTemplate<Void>> handleCreateParcel(
+    public ResponseEntity<RspTemplate<Void>> handleCreateParcel(
                 @PathVariable Long undelivParcelPostId, @RequestBody CreateUndelivParcelDto.Req reqDto
             ) {
         Long undelivParcelId = undeliveredParcelService.create(undelivParcelPostId, reqDto);
 
-        ResTemplate<Void> resTemplate = new ResTemplate<>(HttpStatus.CREATED,
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED,
                 "관리대장에 " + undelivParcelId + "번 관리물품 작성");
-        return ResponseEntity.status(HttpStatus.CREATED).body(resTemplate);
+        return ResponseEntity.status(HttpStatus.CREATED).body(rspTemplate);
     }
 
     // 게시글 상세 조회
     @GetMapping("/posts/undelivered-parcel/{undelivParcelPostId}")
-    public ResTemplate<UndelivParcelPostDetailDto.Res> handleGetParcels(
+    public RspTemplate<UndelivParcelPostDetailDto.Res> handleGetParcels(
             @PathVariable Long undelivParcelPostId
     ) {
         UndeliveredParcelPost undelivParcelPost = undelivParcelPostService.getByIdFetchParcels(undelivParcelPostId);
 
         UndelivParcelPostDetailDto.Res resDto = UndelivParcelPostDetailDto.Res.from(undelivParcelPost);
-        return new ResTemplate<>(HttpStatus.OK, "택배 관리대장 게시물 상세조회", resDto);
+        return new RspTemplate<>(HttpStatus.OK, "택배 관리대장 게시물 상세조회", resDto);
     }
 
     // 관리물품 단건 수정
     @PatchMapping("/undelivParcels/{undelivParcelId}")
-    public ResTemplate<Void> handleUpdateParcel(
+    public RspTemplate<Void> handleUpdateParcel(
             @PathVariable Long undelivParcelId, @RequestBody UpdateUndelivParcelDto.Req reqDto
     ) {
         // parcelId 조회, 값 바꿔치기, 저장하기
         long updatedId = undeliveredParcelService.update(undelivParcelId, reqDto);
 
-        return new ResTemplate<>(HttpStatus.OK, updatedId + "번 관리물품 수정");
+        return new RspTemplate<>(HttpStatus.OK, updatedId + "번 관리물품 수정");
     }
 
     // 관리물품 단건 삭제
     @DeleteMapping("/undelivParcels/{undelivParcelId}")
-    public ResTemplate<Void> handleDeleteParcel(
+    public RspTemplate<Void> handleDeleteParcel(
             @PathVariable Long undelivParcelId
     ) {
         long deleteId = undeliveredParcelService.delete(undelivParcelId);
 
-        return new ResTemplate<>(HttpStatus.OK, deleteId + "번 관리물품 삭제");
+        return new RspTemplate<>(HttpStatus.OK, deleteId + "번 관리물품 삭제");
     }
 
 }

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/controller/UndeliveredParcelController.java
@@ -111,7 +111,6 @@ public class UndeliveredParcelController {
     public ResTemplate<Void> handleDeleteParcel(
             @PathVariable Long undelivParcelId
     ) {
-        // parcelId 조회, 값 바꿔치기, 저장하기
         long deleteId = undeliveredParcelService.delete(undelivParcelId);
 
         return new ResTemplate<>(HttpStatus.OK, deleteId + "번 관리물품 삭제");

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/dto/UndelivParcelPostListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/dto/UndelivParcelPostListDto.java
@@ -1,18 +1,16 @@
 package com.dominest.dominestbackend.api.post.undeliveredparcel.dto;
 
+import com.dominest.dominestbackend.api.common.AuditLog;
 import com.dominest.dominestbackend.api.common.CategoryDto;
 import com.dominest.dominestbackend.api.common.PageInfoDto;
 import com.dominest.dominestbackend.domain.post.component.category.Category;
 import com.dominest.dominestbackend.domain.post.undeliveredparcel.UndeliveredParcelPost;
-import com.dominest.dominestbackend.global.util.PrincipalUtil;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,13 +27,13 @@ public class UndelivParcelPostListDto {
             CategoryDto categoryDto = CategoryDto.from(category);
             PageInfoDto pageInfoDto = PageInfoDto.from(postPage);
 
-            List<UndelivParcelPostListDto.Res.UndelivParcelPostDto> posts
-                    = UndelivParcelPostListDto.Res.UndelivParcelPostDto.from(postPage);
+            List<UndelivParcelPostDto> posts
+                    = UndelivParcelPostDto.from(postPage);
 
-            return new UndelivParcelPostListDto.Res(pageInfoDto, posts, categoryDto);
+            return new Res(pageInfoDto, posts, categoryDto);
         }
 
-        Res(PageInfoDto page, List<UndelivParcelPostListDto.Res.UndelivParcelPostDto> posts, CategoryDto category) {
+        Res(PageInfoDto page, List<UndelivParcelPostDto> posts, CategoryDto category) {
             this.page = page;
             this.posts = posts;
             this.category = category;
@@ -44,24 +42,21 @@ public class UndelivParcelPostListDto {
         @Builder
         @Getter
         static class UndelivParcelPostDto {
-             long id;
+            long id;
             String title;
-            String lastModifiedBy;
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-            LocalDateTime lastModifiedTime;
+            AuditLog auditLog;
 
-            static UndelivParcelPostListDto.Res.UndelivParcelPostDto from(UndeliveredParcelPost post){
+            static UndelivParcelPostDto from(UndeliveredParcelPost post){
                 return UndelivParcelPostListDto.Res.UndelivParcelPostDto.builder()
                         .id(post.getId())
                         .title(post.getTitle())
-                        .lastModifiedBy(PrincipalUtil.strToName(post.getLastModifiedBy()))
-                        .lastModifiedTime(post.getLastModifiedTime())
+                        .auditLog(AuditLog.from(post))
                         .build();
             }
 
-            static List<UndelivParcelPostListDto.Res.UndelivParcelPostDto> from(Page<UndeliveredParcelPost> posts){
+            static List<UndelivParcelPostDto> from(Page<UndeliveredParcelPost> posts){
                 return posts.stream()
-                        .map(UndelivParcelPostListDto.Res.UndelivParcelPostDto::from)
+                        .map(UndelivParcelPostDto::from)
                         .collect(Collectors.toList());
             }
         }

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/dto/UpdateUndelivParcelDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/dto/UpdateUndelivParcelDto.java
@@ -26,13 +26,6 @@ public class UpdateUndelivParcelDto {
         String instruction;
         @NotNull(message = "처리상태는 비어있을 수 없습니다.")
         UndeliveredParcel.ProcessState processState;
-
-        public long updateEntity(UndeliveredParcel undelivParcel) {
-            undelivParcel.updateValues(
-                    this.recipientName, this.recipientPhoneNum
-                    , this.instruction, this.processState);
-            return undelivParcel.getId();
-        }
     }
 }
 

--- a/src/main/java/com/dominest/dominestbackend/api/resident/controller/ResidentController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/resident/controller/ResidentController.java
@@ -1,7 +1,7 @@
 package com.dominest.dominestbackend.api.resident.controller;
 
 
-import com.dominest.dominestbackend.api.common.ResTemplate;
+import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.api.resident.dto.PdfBulkUploadDto;
 import com.dominest.dominestbackend.api.resident.dto.ResidentListDto;
 import com.dominest.dominestbackend.api.resident.dto.ResidentPdfListDto;
@@ -38,7 +38,7 @@ public class ResidentController {
 
     // 엑셀로 업로드
     @PostMapping("/residents/upload-excel")
-    public ResponseEntity<ResTemplate<?>> handleFileUpload(@RequestParam(required = true) MultipartFile file
+    public ResponseEntity<RspTemplate<?>> handleFileUpload(@RequestParam(required = true) MultipartFile file
                                                                                                             , @RequestParam(required = true) ResidenceSemester residenceSemester){
         residentService.excelUpload(file, residenceSemester);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
@@ -46,17 +46,17 @@ public class ResidentController {
 
     // 전체조회
     @GetMapping("/residents")
-    public ResTemplate<ResidentListDto.Res> handleGetAllResident(@RequestParam(required = true) ResidenceSemester residenceSemester){
+    public RspTemplate<ResidentListDto.Res> handleGetAllResident(@RequestParam(required = true) ResidenceSemester residenceSemester){
 
         List<Resident> residents = residentService.getAllResidentByResidenceSemester(residenceSemester);
 
         ResidentListDto.Res resDto = ResidentListDto.Res.from(residents);
-        return new ResTemplate<>(HttpStatus.OK, "입사생 목록 조회 성공", resDto);
+        return new RspTemplate<>(HttpStatus.OK, "입사생 목록 조회 성공", resDto);
     }
 
     // (테스트용) 입사생 데이터 전체삭제
     @DeleteMapping("/residents")
-    public ResponseEntity<ResTemplate<?>> handleDeleteAllResident(){
+    public ResponseEntity<RspTemplate<?>> handleDeleteAllResident(){
         residentService.deleteAllResident();
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
@@ -64,7 +64,7 @@ public class ResidentController {
 
     // 입사생 단건 등록. 단순 DTO 변환 후 저장만 하면 될듯
     @PostMapping("/residents")
-    public ResponseEntity<ResTemplate<?>> handleSaveResident(@RequestBody @Valid SaveResidentDto.Req reqDto){
+    public ResponseEntity<RspTemplate<?>> handleSaveResident(@RequestBody @Valid SaveResidentDto.Req reqDto){
         residentService.saveResident(reqDto.toEntity());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -72,7 +72,7 @@ public class ResidentController {
 
     // 입사생 수정
     @PatchMapping("/residents/{id}")
-    public ResponseEntity<ResTemplate<?>> handleUpdateResident(@PathVariable Long id, @RequestBody @Valid SaveResidentDto.Req reqDto){
+    public ResponseEntity<RspTemplate<?>> handleUpdateResident(@PathVariable Long id, @RequestBody @Valid SaveResidentDto.Req reqDto){
         try {
             residentService.updateResident(id, reqDto.toEntity());
         }catch (DataIntegrityViolationException e) {
@@ -84,15 +84,15 @@ public class ResidentController {
 
     // 입사생 삭제
     @DeleteMapping("/residents/{id}")
-    public ResponseEntity<ResTemplate<?>> handleDeleteResident(@PathVariable Long id){
+    public ResponseEntity<RspTemplate<?>> handleDeleteResident(@PathVariable Long id){
         residentService.deleteById(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     // 특정 입사생의 PDF 조회
     @GetMapping("/residents/{id}/pdf")
-    public ResTemplate<?> handleGetPdf(@PathVariable Long id,  @RequestParam(required = true) PdfType pdfType,
-                                                                        HttpServletResponse response){
+    public RspTemplate<?> handleGetPdf(@PathVariable Long id, @RequestParam(required = true) PdfType pdfType,
+                                       HttpServletResponse response){
         // filename 가져오기.
         Resident resident = residentService.findById(id);
 
@@ -110,45 +110,45 @@ public class ResidentController {
         } catch (IOException e) {
             throw new FileIOException(ErrorCode.FILE_CANNOT_BE_SENT);
         }
-        return new ResTemplate<>(HttpStatus.OK, "pdf 조회 성공");
+        return new RspTemplate<>(HttpStatus.OK, "pdf 조회 성공");
     }
 
     // PDF 단건 업로드
     @PostMapping("/residents/{id}/pdf")
-    public ResponseEntity<ResTemplate<String>> handlePdfUpload(@PathVariable Long id, @RequestParam(required = true) MultipartFile pdf,
-                                                                                                                    @RequestParam(required = true) PdfType pdfType){
+    public ResponseEntity<RspTemplate<String>> handlePdfUpload(@PathVariable Long id, @RequestParam(required = true) MultipartFile pdf,
+                                                               @RequestParam(required = true) PdfType pdfType){
         FileService.FilePrefix filePrefix = pdfType.toFilePrefix();
 
         residentService.uploadPdf(id, filePrefix, pdf);
-        ResTemplate<String> resTemplate = new ResTemplate<>(HttpStatus.CREATED, "pdf 업로드 완료");
+        RspTemplate<String> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, "pdf 업로드 완료");
         return ResponseEntity
                 .created(URI.create("/residents/"+id+"/pdf"))
-                .body(resTemplate);
+                .body(rspTemplate);
     }
 
     // PDF 전체 업로드
     @PostMapping("/residents/pdf")
-    public ResponseEntity<ResTemplate<PdfBulkUploadDto.Res>> handlePdfUpload(@RequestParam(required = true) List<MultipartFile> pdfs
+    public ResponseEntity<RspTemplate<PdfBulkUploadDto.Res>> handlePdfUpload(@RequestParam(required = true) List<MultipartFile> pdfs
                                                                                                                     , @RequestParam(required = true) ResidenceSemester residenceSemester
                                                                                                                     , @RequestParam(required = true) PdfType pdfType){
         FileService.FilePrefix filePrefix = pdfType.toFilePrefix();
         PdfBulkUploadDto.Res resDto = residentService.uploadPdfs(filePrefix, pdfs, residenceSemester);
 
-        ResTemplate<PdfBulkUploadDto.Res> resTemplate = new ResTemplate<>(HttpStatus.CREATED,
+        RspTemplate<PdfBulkUploadDto.Res> rspTemplate = new RspTemplate<>(HttpStatus.CREATED,
                 "pdf 업로드 완료. 저장된 파일 수: " + resDto.getSuccessCount() + "개", resDto);
         return ResponseEntity
                 .created(URI.create("/residents/pdf"))
-                .body(resTemplate);
+                .body(rspTemplate);
     }
 
     // 해당차수 입사생 전체 PDF 조회
     @GetMapping("/residents/pdf")
-    public ResTemplate<ResidentPdfListDto.Res> handleGetAllPdfs(@RequestParam(required = true) ResidenceSemester residenceSemester){
+    public RspTemplate<ResidentPdfListDto.Res> handleGetAllPdfs(@RequestParam(required = true) ResidenceSemester residenceSemester){
 
         List<Resident> residents = residentService.getAllPdfs(residenceSemester);
 
         ResidentPdfListDto.Res resDto = ResidentPdfListDto.Res.from(residents);
-        return new ResTemplate<>(HttpStatus.OK
+        return new RspTemplate<>(HttpStatus.OK
                 , "pdf url 조회 성공"
                 , resDto);
     }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/common/Post.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/common/Post.java
@@ -25,8 +25,7 @@ public abstract class Post extends BaseEntity {
     @Column(nullable = false)
     private String title;
     /*작성자의 이름이다. String으로 작성자이름만 넣을까 했으나,
-      토큰 인증방식이라 '상태'를 서버에서 관리할 수 없어, 삭제된 사용자의 정보가 들어갈 가능성이 있으므로
-      User 객체를 넣어 외래키 연관관계를 맺도록 함.*/
+      사용자를 특정할 수 있는 ID를 넣어야 하므로 User 객체를 넣어 외래키 연관관계를 맺도록 함.*/
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "writer_id")
     private User writer;

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -19,7 +19,7 @@ public class Complaint extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String roomNo; // 호수
+    private String roomNo; // 호실
     @Column(nullable = false)
     private String complaintCause; // 민원내역. FtIdx 만들어야 함.
     @Column(nullable = false)

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -21,11 +21,17 @@ public class Complaint extends BaseEntity {
     @Column(nullable = false)
     private String roomNo; // 호수
     @Column(nullable = false)
-    private LocalDate date; // 민원접수일자
-    @Column(nullable = false)
     private String complaintCause; // 민원내역. FtIdx 만들어야 함.
     @Column(nullable = false)
     private String complaintResolution; // 민원처리내역. FtIdx 만들어야 함.
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ProcessState processState; // 처리상태
+
+    @Column(nullable = false)
+    private LocalDate date; // 민원접수일자
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "writer_id")
@@ -36,11 +42,12 @@ public class Complaint extends BaseEntity {
     private Category category;
 
     @Builder
-    private Complaint(String roomNo, LocalDate date, String complaintCause, String complaintResolution, User writer, Category category) {
+    private Complaint(String roomNo, String complaintCause, String complaintResolution, ProcessState processState, LocalDate date, User writer, Category category) {
         this.roomNo = roomNo;
-        this.date = date;
         this.complaintCause = complaintCause;
         this.complaintResolution = complaintResolution;
+        this.processState = processState;
+        this.date = date;
         this.writer = writer;
         this.category = category;
     }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -1,0 +1,56 @@
+package com.dominest.dominestbackend.domain.post.complaint;
+
+import com.dominest.dominestbackend.domain.common.BaseEntity;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Complaint extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String roomNo; // 호수
+    @Column(nullable = false)
+    private LocalDate date; // 민원접수일자
+    @Column(nullable = false)
+    private String complaintCause; // 민원내역. FtIdx 만들어야 함.
+    @Column(nullable = false)
+    private String complaintResolution; // 민원처리내역. FtIdx 만들어야 함.
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "writer_id")
+    private User writer;    // 작성자 정보
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "category_id")
+    private Category category;
+
+    @Builder
+    private Complaint(String roomNo, LocalDate date, String complaintCause, String complaintResolution, User writer, Category category) {
+        this.roomNo = roomNo;
+        this.date = date;
+        this.complaintCause = complaintCause;
+        this.complaintResolution = complaintResolution;
+        this.writer = writer;
+        this.category = category;
+    }
+
+    // 처리 결과는 (접수완료, 처리중, 처리완료 중 하나)
+    @RequiredArgsConstructor
+    public enum ProcessState {
+        RECEIPT_COMPLETED("접수완료"), PROCESSING("처리중"), PROCESS_COMPLETED("처리완료");
+
+        @JsonValue // 직렬화, 역직렬화 시 사용될 값
+        private final String state;
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -52,6 +52,16 @@ public class Complaint extends BaseEntity {
         this.category = category;
     }
 
+    public void updateValues(String roomNo, String complaintCause, String complaintResolution, ProcessState processState, LocalDate date) {
+        this.roomNo = roomNo;
+        this.complaintCause = complaintCause;
+        this.complaintResolution = complaintResolution;
+        this.processState = processState;
+        this.date = date;
+    }
+
+
+
     // 처리 결과는 (접수완료, 처리중, 처리완료 중 하나)
     @RequiredArgsConstructor
     public enum ProcessState {

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
@@ -1,6 +1,15 @@
 package com.dominest.dominestbackend.domain.post.complaint;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
+
+    @Query(value = "SELECT c FROM Complaint c" +
+            " WHERE c.category.id = :categoryId"
+            , countQuery = "SELECT count(c) FROM Complaint c WHERE c.category.id = :categoryId")
+    Page<Complaint> findAllByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
@@ -1,0 +1,6 @@
+package com.dominest.dominestbackend.domain.post.complaint;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -10,6 +10,8 @@ import com.dominest.dominestbackend.domain.user.service.UserService;
 import com.dominest.dominestbackend.global.exception.ErrorCode;
 import com.dominest.dominestbackend.global.util.EntityUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,6 +59,10 @@ public class ComplaintService {
         Complaint complaint = getById(complaintId);
         complaintRepository.delete(complaint);
         return complaint.getId();
+    }
+
+    public Page<Complaint> getPage(Long categoryId, Pageable pageable) {
+        return complaintRepository.findAllByCategoryId(categoryId, pageable);
     }
 }
 

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -1,0 +1,12 @@
+package com.dominest.dominestbackend.domain.post.complaint;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ComplaintService {
+    private final ComplaintRepository complaintRepository;
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -1,11 +1,14 @@
 package com.dominest.dominestbackend.domain.post.complaint;
 
 import com.dominest.dominestbackend.api.post.complaint.dto.CreateComplaintDto;
+import com.dominest.dominestbackend.api.post.complaint.dto.UpdateComplaintDto;
 import com.dominest.dominestbackend.domain.post.component.category.Category;
 import com.dominest.dominestbackend.domain.post.component.category.component.Type;
 import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
 import com.dominest.dominestbackend.domain.user.User;
 import com.dominest.dominestbackend.domain.user.service.UserService;
+import com.dominest.dominestbackend.global.exception.ErrorCode;
+import com.dominest.dominestbackend.global.util.EntityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,4 +33,45 @@ public class ComplaintService {
         // Complaint 객체 생성 후 저장
         return complaintRepository.save(complaint).getId();
     }
+
+    @Transactional
+    public long update(Long complaintId, UpdateComplaintDto.Req reqDto) {
+        Complaint complaint = getById(complaintId);
+
+        complaint.updateValues(
+                reqDto.getRoomNo()
+                , reqDto.getComplaintCause()
+                , reqDto.getComplaintResolution()
+                , reqDto.getProcessState()
+                , reqDto.getDate()
+        );
+        return complaint.getId();
+    }
+
+    public Complaint getById(Long id) {
+        return EntityUtil.mustNotNull(complaintRepository.findById(id), ErrorCode.COMPLAINT_NOT_FOUND);
+    }
+
+    @Transactional
+    public long delete(Long complaintId) {
+        Complaint complaint = getById(complaintId);
+        complaintRepository.delete(complaint);
+        return complaint.getId();
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -1,5 +1,11 @@
 package com.dominest.dominestbackend.domain.post.complaint;
 
+import com.dominest.dominestbackend.api.post.complaint.dto.CreateComplaintDto;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.post.component.category.component.Type;
+import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
+import com.dominest.dominestbackend.domain.user.User;
+import com.dominest.dominestbackend.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +15,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ComplaintService {
     private final ComplaintRepository complaintRepository;
+    private final UserService userService;
+    private final CategoryService categoryService;
+
+    @Transactional
+    public long create(CreateComplaintDto.Req reqDto, Long categoryId, String email) {
+        // Complaint 연관 객체인 category, user 찾기
+        User user = userService.getUserByEmail(email);
+        // Complaint 연관 객체인 category 찾기
+        Category category = categoryService.validateCategoryType(categoryId, Type.COMPLAINT);
+
+        Complaint complaint = reqDto.toEntity(user, category);
+
+        // Complaint 객체 생성 후 저장
+        return complaintRepository.save(complaint).getId();
+    }
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/component/Type.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/component/Type.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum Type {
     IMAGE("image-types"), TEXT_IMAGE("text-image-types")
     , UNDELIVERED_PARCEL_REGISTER("undelivered-parcel")
+    , COMPLAINT("complaint")
     ;
 
     private final String url;

--- a/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/UndeliveredParcelPostRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/UndeliveredParcelPostRepository.java
@@ -9,8 +9,7 @@ import org.springframework.data.repository.query.Param;
 public interface UndeliveredParcelPostRepository extends JpaRepository<UndeliveredParcelPost, Long> {
 
     @Query(value = "SELECT p FROM UndeliveredParcelPost p" +
-            " WHERE p.category.id = :categoryId" +
-            " ORDER BY p.id DESC"
+            " WHERE p.category.id = :categoryId"
             , countQuery = "SELECT count(p) FROM UndeliveredParcelPost p WHERE p.category.id = :categoryId")
     Page<UndeliveredParcelPost> findAllByCategory(@Param("categoryId") Long categoryId, Pageable pageable);
 

--- a/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/component/UndeliveredParcel.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/component/UndeliveredParcel.java
@@ -58,7 +58,7 @@ public class UndeliveredParcel extends BaseEntity {
         MESSAGE_SENT("문자발송"), CALL_COMPLETED("전화완료"),
         DISCARD_SCHEDULED("폐기예정"), DISCARD_COMPLETED("폐기완료");
 
-        @JsonValue // 직렬화 시 사용될 값
+        @JsonValue // 직렬화, 역직렬화 시 사용될 값
         private final String state;
     }
 

--- a/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/component/UndeliveredParcelService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/component/UndeliveredParcelService.java
@@ -40,7 +40,14 @@ public class UndeliveredParcelService {
     @Transactional
     public long update(Long undelivParcelId, UpdateUndelivParcelDto.Req reqDto) {
         UndeliveredParcel undelivParcel = getById(undelivParcelId);
-        return reqDto.updateEntity(undelivParcel);
+        undelivParcel.updateValues(
+                reqDto.getRecipientName()
+                , reqDto.getRecipientPhoneNum()
+                , reqDto.getInstruction()
+                , reqDto.getProcessState()
+        );
+
+        return undelivParcel.getId();
     }
 
     public UndeliveredParcel getById(Long undelivParcelId) {

--- a/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
@@ -59,6 +59,8 @@ public enum ErrorCode {
     // 미수령 택배
     UNDELIVERED_PARCEL_NOT_FOUND(404, "해당 관리물품이 존재하지 않습니다."),
 
+    // 민원내역
+    COMPLAINT_NOT_FOUND(404, "해당 민원이 존재하지 않습니다."),
     ;
     private final int statusCode;
     private final String message;

--- a/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
@@ -39,25 +39,27 @@ public class InitDB {
     @Transactional
     @PostConstruct
     public void init() {
+        final String PHONE_NUM = "010-1234-5678";
+        final String PWD = "pppp";
         User user = User.builder()
                 .email("eeee@email.com")
-                .password(passwordEncoder.encode("pppp"))
+                .password(passwordEncoder.encode(PWD))
                 .name("name1")
-                .phoneNumber("010-1234-5678")
+                .phoneNumber(PHONE_NUM)
                 .role(Role.ROLE_ADMIN)
                 .build();
         User user2 = User.builder()
                 .email("eeee1@email.com")
-                .password(passwordEncoder.encode("pppp"))
+                .password(passwordEncoder.encode(PWD))
                 .name("name2")
-                .phoneNumber("010-1235-5678")
+                .phoneNumber(PHONE_NUM)
                 .role(Role.ROLE_ADMIN)
                 .build();
         User user3 = User.builder()
                 .email("eeee2@email.com")
-                .password(passwordEncoder.encode("pppp"))
+                .password(passwordEncoder.encode(PWD))
                 .name("name3")
-                .phoneNumber("010-1236-5678")
+                .phoneNumber(PHONE_NUM)
                 .role(Role.ROLE_ADMIN)
                 .build();
         userRepository.save(user);
@@ -71,6 +73,13 @@ public class InitDB {
                 .explanation("장미택관")
                 .build();
         categoryRepository.save(category1);
+
+        Category category2 = Category.builder()
+                .name("민원처리내역")
+                .type(Type.COMPLAINT)
+                .explanation("민처내")
+                .build();
+        categoryRepository.save(category2);
         
         UndeliveredParcelPost unDeliParcelPost = UndeliveredParcelPost.builder()
                 .titleWithCurrentDate(createTitle())
@@ -95,14 +104,6 @@ public class InitDB {
                 .build();
         undelivParcelRepository.save(parcel);
         undelivParcelRepository.save(parcel2);
-
-
-        Category category2 = Category.builder()
-                .name("이미지타입1")
-                .type(Type.IMAGE)
-                .explanation("explanation")
-                .build();
-        categoryRepository.save(category2);
 
 
         ArrayList<Category> categories = new ArrayList<>();

--- a/src/main/java/com/dominest/dominestbackend/global/util/PageableUtil.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/PageableUtil.java
@@ -1,8 +1,12 @@
 package com.dominest.dominestbackend.global.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PageableUtil {
 
     /** 0-base인 페이지를 클라이언트단에서 1-based인 것처럼 사용할 수 있게 한다.
@@ -15,5 +19,12 @@ public class PageableUtil {
             throw new IllegalArgumentException("page는 1 이상이어야 합니다.");
 
         return PageRequest.of(oneBasedPage - 1 , size);
+    }
+
+    public static Pageable of(int oneBasedPage, int size, Sort sort) {
+        if (oneBasedPage < 1)
+            throw new IllegalArgumentException("page는 1 이상이어야 합니다.");
+
+        return PageRequest.of(oneBasedPage - 1 , size, sort);
     }
 }


### PR DESCRIPTION
## 요약
- 민원 등록, 수정, 삭제, 전체조회 추가
- 관리물품 수정/삭제 추가

## 추가사항
**민원 CRUD -> ComplaintController.java**
- @PostMapping("/categories/{categoryId}/posts/complaint") // 등록
- @PatchMapping("/complaints/{complaintId}") // 수정
- @DeleteMapping("/complaints/{complaintId}") // 삭제
- @GetMapping("/categories/{categoryId}/posts/complaint") // 목록조회

**미수령 택배 수정/삭제 -> UndeliveredParcelController.java
- @PatchMapping("/undelivParcels/{undelivParcelId}") // 관리물품 단건 수정
- @DeleteMapping("/undelivParcels/{undelivParcelId}") // 관리물품 단건 삭제
- 
## 수정사항
1. [Rename: 공통응답객체 ResTemplate -> RspTemplate]
- 명확성을 위해, 스프링 제공 RestTemplate과의 혼동을 피하기 위해 이름 변경
2. [Refactor: DB Order By 대신 Sort 객체 사용]
- Order By절의 조건을 메서드 이름에 포함하지 않아도 의미를 표현 가능하게끔 변경.
3. [Update: API 응답용 유틸리티 클래스 AuditLog 추가와 적용]
- 자주 쓰이는 BaseEntity쪽 값들을 사용할 수 있게 함.