### PR TITLE
카테고리 '정렬순서' 기능 적용과 코드 리팩터링

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
@@ -1,6 +1,6 @@
 package com.dominest.dominestbackend.api.category.controller;
 
-import com.dominest.dominestbackend.api.category.request.CategoryCreateRequest;
+import com.dominest.dominestbackend.api.category.request.CreateCategoryRequest;
 import com.dominest.dominestbackend.api.category.request.CategoryUpdateRequest;
 import com.dominest.dominestbackend.api.category.response.CategoryListDto;
 import com.dominest.dominestbackend.api.category.response.CategoryListWithFavoriteDto;
@@ -27,7 +27,8 @@ public class CategoryController {
     private final CategoryService categoryService;
     private final CategoryRepository categoryRepository;
 
-    @GetMapping("/categories") // 카테고리 조회
+    // 카테고리 관리페이지 목록 조회, orderKey ASC로 조회.
+    @GetMapping("/categories")
     public RspTemplate<CategoryListDto.Res> handleGetCategoryList() {
 
         List<Category> categories = categoryRepository.findAll();
@@ -48,12 +49,17 @@ public class CategoryController {
     }
 
     @PostMapping ("/categories")// 카테고리 생성
-    public ResponseEntity<RspTemplate<Void>> createCategory(@RequestBody @Valid final CategoryCreateRequest request) {
+    public ResponseEntity<RspTemplate<Void>> createCategory(
+            @RequestBody @Valid final CreateCategoryRequest reqDto
+    ) {
+        Category category = categoryService.create(reqDto.getCategoryName(), reqDto.getCategoryType(), reqDto.getExplanation());
 
-        Category category = categoryService.create(request.getCategoryName(), request.getCategoryType(), request.getExplanation());
-        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, "카테고리 생성 성공");
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(
+                HttpStatus.CREATED
+                , category.getId() + "번 " + category.getName() + " 카테고리 생성 성공"
+        );
         return ResponseEntity
-                .created(URI.create("/categories/" + category.getId()))
+                .created(URI.create(category.getPostsLink()))
                 .body(rspTemplate);
     }
 

--- a/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
@@ -45,7 +45,9 @@ public class CategoryController {
         // 즐찾목록 다 조회해서 카테고리 ID들을 찾아낸다.
         // 찾아낸 카테고리 ID들과 전체 카테고리 목록 중 일치하는 것들은 즐겨찾기가 되어있는 것이다.
         List<Long> categoryIdsFromFavorites = categoryService.getIdAllByUserEmail(PrincipalUtil.toEmail(principal));
-        List<Category> categories = categoryRepository.findAll();
+
+        Sort sort = Sort.by("orderKey");
+        List<Category> categories = categoryRepository.findAll(sort);
 
         CategoryListWithFavoriteDto.Res resDto = CategoryListWithFavoriteDto.Res.from(categories, categoryIdsFromFavorites);
         return new RspTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
@@ -67,17 +69,15 @@ public class CategoryController {
     }
 
     @PutMapping("/categories") // 카테고리 수정
-    public RspTemplate<String> updateCategories(@RequestBody @Valid final List<CategoryUpdateRequest> requests) throws Exception {
-
-        for (CategoryUpdateRequest request : requests) {
-            categoryService.update(request.getId(), request.getCategoryName());
-        }
-        return new RspTemplate<>(HttpStatus.OK, "카테고리 수정 성공");
+    public RspTemplate<String> updateCategories(@RequestBody @Valid final CategoryUpdateRequest reqDto
+    ) {
+        int updateCount = categoryService.update(reqDto);
+        return new RspTemplate<>(HttpStatus.OK
+                , updateCount + "개의 카테고리 변경 요청 성공");
     }
 
     @DeleteMapping("/categories/{id}") // 카테고리 삭제
     public RspTemplate<String> deleteCategory(@PathVariable Long id) {
-
         categoryService.deleteById(id);
         return new RspTemplate<>(HttpStatus.OK, id +"번 카테고리 삭제 성공");
     }

--- a/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/controller/CategoryController.java
@@ -10,6 +10,7 @@ import com.dominest.dominestbackend.domain.post.component.category.repository.Ca
 import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
 import com.dominest.dominestbackend.global.util.PrincipalUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,10 +29,12 @@ public class CategoryController {
     private final CategoryRepository categoryRepository;
 
     // 카테고리 관리페이지 목록 조회, orderKey ASC로 조회.
+    // 페이지네이션 하지 않음.
     @GetMapping("/categories")
     public RspTemplate<CategoryListDto.Res> handleGetCategoryList() {
+        Sort sort = Sort.by("orderKey");
+        List<Category> categories = categoryRepository.findAll(sort);
 
-        List<Category> categories = categoryRepository.findAll();
         CategoryListDto.Res resDto = CategoryListDto.Res.from(categories);
         return new RspTemplate<>(HttpStatus.OK, "카테고리 조회 성공", resDto);
     }

--- a/src/main/java/com/dominest/dominestbackend/api/category/request/CategoryUpdateRequest.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/request/CategoryUpdateRequest.java
@@ -1,12 +1,32 @@
 package com.dominest.dominestbackend.api.category.request;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@NoArgsConstructor
 @Getter
 public class CategoryUpdateRequest {
-    private Long id;
-    private String categoryName;
+    @NotNull(message = "카테고리 목록은 필수 입력 값입니다")
+    @Valid
+    List<CategoryDto> categories;
+
+    @NoArgsConstructor
+    @Getter
+    public static class CategoryDto {
+        @NotNull(message = "카테고리 ID는 필수 입력 값입니다")
+        @Positive(message = "카테고리 ID는 0보다 커야합니다")
+        Long id;
+        @NotBlank(message = "카테고리 이름은 필수 입력 값입니다")
+        String categoryName;
+        String explanation = "";
+        @NotNull(message = "카테고리 정렬 순서는 필수 입력 값입니다")
+        @Positive(message = "카테고리 정렬 순서는 0보다 커야합니다")
+        Integer orderKey;
+    }
 }

--- a/src/main/java/com/dominest/dominestbackend/api/category/request/CreateCategoryRequest.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/request/CreateCategoryRequest.java
@@ -10,11 +10,11 @@ import javax.validation.constraints.NotNull;
 
 @NoArgsConstructor
 @Getter
-public class CategoryCreateRequest {
-    @NotBlank(message = "카테고리 이름은 필수 입력 값입니다.")
+public class CreateCategoryRequest {
+    @NotBlank(message = "카테고리 이름은 필수 입력 값입니다")
     @Length(max = 255, message = "카테고리 이름은 255자 이내로 입력해주세요.")
     private String categoryName;
-    @NotNull(message = "카테고리 타입은 필수 입력 값입니다.")
+    @NotNull(message = "카테고리 타입은 필수 입력 값입니다")
     private Type categoryType;
-    private String explanation;
+    private String explanation = "";
 }

--- a/src/main/java/com/dominest/dominestbackend/api/category/response/CategoryListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/response/CategoryListDto.java
@@ -2,13 +2,15 @@ package com.dominest.dominestbackend.api.category.response;
 
 import com.dominest.dominestbackend.domain.post.component.category.Category;
 import com.dominest.dominestbackend.domain.post.component.category.component.Type;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CategoryListDto {
     @Getter
     public static class Res {
@@ -28,6 +30,7 @@ public class CategoryListDto {
             String name; // 카테고리 이름
             Type type;
             String explanation; // 카테고리 상세설명
+            String categoryLink; // 카테고리 게시글 목록으로 이동하는 링크
 
             static CategoryDto from(Category category) {
                 return CategoryDto.builder()
@@ -35,6 +38,7 @@ public class CategoryListDto {
                         .name(category.getName())
                         .type(category.getType())
                         .explanation(category.getExplanation())
+                        .categoryLink(category.getPostsLink())
                         .build();
             }
 

--- a/src/main/java/com/dominest/dominestbackend/api/category/response/CategoryListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/category/response/CategoryListDto.java
@@ -26,7 +26,8 @@ public class CategoryListDto {
         @Builder
         @Getter
         private static class CategoryDto{
-            Long id;
+            long id;
+            int orderKey;
             String name; // 카테고리 이름
             Type type;
             String explanation; // 카테고리 상세설명
@@ -35,6 +36,7 @@ public class CategoryListDto {
             static CategoryDto from(Category category) {
                 return CategoryDto.builder()
                         .id(category.getId())
+                        .orderKey(category.getOrderKey())
                         .name(category.getName())
                         .type(category.getType())
                         .explanation(category.getExplanation())

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
@@ -29,4 +29,6 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
             , countQuery = "SELECT count(c) FROM Complaint c WHERE c.category.id = :categoryId AND c.roomNo = :roomNoSch"
     )
     Page<Complaint> findAllByCategoryIdAndRoomNo(@Param("categoryId") Long categoryId, @Param("roomNoSch") String roomNoSch, Pageable pageable);
+
+    void deleteByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/Category.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/Category.java
@@ -12,7 +12,10 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "Category")
+@Table(indexes = {
+        @Index(name = "idx_category_orderKey"
+                    , columnList = "order_key, type, name, id, explanation") // covering index
+        })
 public class Category extends BaseEntity {
 
     @Id
@@ -25,14 +28,18 @@ public class Category extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Type type;
 
-    @Column(length = 255, nullable = false)
+    @Column(nullable = false)
     private String explanation; // 카테고리 상세설명
 
+    @Column(nullable = false)
+    private Integer orderKey;   // 정렬 기준
+
     @Builder
-    public Category(String name, Type type, String explanation) {
+    public Category(String name, Type type, String explanation, Integer orderKey) {
         this.name = name;
         this.type = type;
         this.explanation = explanation;
+        this.orderKey = orderKey;
     }
 
     public String getPostsLink(){

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/Category.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/Category.java
@@ -12,10 +12,6 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(indexes = {
-        @Index(name = "idx_category_orderKey"
-                    , columnList = "order_key, type, name, id, explanation") // covering index
-        })
 public class Category extends BaseEntity {
 
     @Id
@@ -46,7 +42,10 @@ public class Category extends BaseEntity {
         return  "/categories/" + getId() + "/posts/" + getType().getUrl();
     }
 
-    public void updateCategory(String updatedCategoryName) {
-        this.name = updatedCategoryName;
+    // update name, explanation, orderKey
+    public void updateValues(String name, String explanation, Integer orderKey) {
+        this.name = name;
+        this.explanation = explanation;
+        this.orderKey = orderKey;
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/repository/CategoryRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/repository/CategoryRepository.java
@@ -17,4 +17,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT COALESCE(MAX(c.orderKey) + 1, 1) FROM Category c")
     Integer getNewOrderKey();
+
+    @Query("SELECT c.orderKey FROM Category c")
+    List<Integer> findAllOrderKey();
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/repository/CategoryRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/repository/CategoryRepository.java
@@ -14,4 +14,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
             " WHERE u.email = :email AND f.onOff = true")
         // userEmail은 조회결과가 아니라 조건이므로 Fetch하지 않아도 될 듯?
     List<Long> findIdAllByUserEmailFetchCategory(@Param("email") String email);
+
+    @Query("SELECT COALESCE(MAX(c.orderKey) + 1, 1) FROM Category c")
+    Integer getNewOrderKey();
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/image/ImageTypeRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/image/ImageTypeRepository.java
@@ -20,4 +20,6 @@ public interface ImageTypeRepository extends JpaRepository<ImageType, Long> {
             " LEFT JOIN FETCH i.imageUrls" +
             " WHERE i.id = :imageTypeId")
     ImageType findByIdFetchImageUrls(@Param("imageTypeId") Long imageTypeId);
+
+    void deleteByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/UndeliveredParcelPostRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/undeliveredparcel/UndeliveredParcelPostRepository.java
@@ -17,4 +17,6 @@ public interface UndeliveredParcelPostRepository extends JpaRepository<Undeliver
             " LEFT JOIN FETCH p.undelivParcels" +
             " WHERE p.id = :postId")
     UndeliveredParcelPost findByIdFetchParcels(@Param("postId") Long undelivParcelPostId);
+
+    void deleteByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     // 카테고리
     CATEGORY_NOT_FOUND(404, "해당 카테고리가 존재하지 않습니다."),
     CATEGORY_TYPE_MISMATCHED(400, "해당 카테고리의 타입이 일치하지 않습니다."),
+    CATEGORY_ORDER_KEY_DUPLICATED(400, "카테고리의 orderKey가 중복됩니다."),
     // 게시글 공통
     POST_NOT_FOUND(404, "해당 게시글이 존재하지 않습니다."),
 
@@ -65,6 +66,9 @@ public enum ErrorCode {
     // 민원내역
     COMPLAINT_NOT_FOUND(404, "해당 민원이 존재하지 않습니다."),
     ;
+
+
+
     private final int statusCode;
     private final String message;
 

--- a/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
@@ -74,6 +74,7 @@ public class InitDB {
                 .name("장기 미수령 택배 관리대장")
                 .type(Type.UNDELIVERED_PARCEL_REGISTER)
                 .explanation("장미택관")
+                .orderKey(1)
                 .build();
         categoryRepository.save(category1);
 
@@ -81,6 +82,7 @@ public class InitDB {
                 .name("민원처리내역")
                 .type(Type.COMPLAINT)
                 .explanation("민처내")
+                .orderKey(2)
                 .build();
         categoryRepository.save(category2);
         
@@ -116,6 +118,7 @@ public class InitDB {
                     .name("categoryName" + i)
                     .type(Type.IMAGE)
                     .explanation("explanation")
+                    .orderKey(categoryCount + i)
                     .build();
             categories.add(category);
         }


### PR DESCRIPTION
## 요약
- category 객체를 조회할 때 orderKey(정렬단서) 순으로 조회된다.
- category 생성 시 orderKey는 "COALESCE(MAX(c.orderKey) + 1, 1) FROM Category c" 로 정해진다. (DB상 최대값 + 1)

## 수정사항
- 카테고리 삭제 시 연관 게시글 모두 삭제
- 관리화면 카테고리 조회 시 categoryLink 반환 [GET]"/categories"
- category 객체 생성 시 orderKey 값이 정해지고, 조회 시 orderKey 오름차순으로 조회되며, 수정할 수 있다.
