### PR TITLE
Cardkey CRUD 기능, 민원신청내역 '이름' 속성 추가

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/post/cardkey/controller/CardKeyController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/cardkey/controller/CardKeyController.java
@@ -1,0 +1,24 @@
+package com.dominest.dominestbackend.api.post.cardkey.controller;
+
+import com.dominest.dominestbackend.domain.post.cardkey.CardKeyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class CardKeyController {
+    private final CardKeyService cardKeyService;
+
+    // 등록
+
+    // 목록조회
+
+    // 수정
+
+    // 삭제
+
+    // 이름검색 (인덱스 만들고, '검색어%' 로 만들 것
+
+    // 이름검색까지 끝내고 민원대장에 이름
+    // 배포하고나서 테스트 오지게 돌리기 싫으면 테스트코드 성공케이스만이라도 일단 작성하자.
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/cardkey/controller/CardKeyController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/cardkey/controller/CardKeyController.java
@@ -1,23 +1,91 @@
 package com.dominest.dominestbackend.api.post.cardkey.controller;
 
+import com.dominest.dominestbackend.api.common.RspTemplate;
+import com.dominest.dominestbackend.api.post.cardkey.dto.CardKeyListDto;
+import com.dominest.dominestbackend.api.post.cardkey.dto.CreateCardKeyDto;
+import com.dominest.dominestbackend.api.post.cardkey.dto.UpdateCardKeyDto;
+import com.dominest.dominestbackend.domain.post.cardkey.CardKey;
 import com.dominest.dominestbackend.domain.post.cardkey.CardKeyService;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.post.component.category.component.Type;
+import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
+import com.dominest.dominestbackend.global.util.PageableUtil;
+import com.dominest.dominestbackend.global.util.PrincipalUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.security.Principal;
 
 @RequiredArgsConstructor
 @RestController
 public class CardKeyController {
     private final CardKeyService cardKeyService;
+    private final CategoryService categoryService;
 
     // 등록
+    @PostMapping("/categories/{categoryId}/posts/card-key")
+    public ResponseEntity<RspTemplate<Void>> handleCreateComplaint(
+            @RequestBody @Valid CreateCardKeyDto.Req reqDto
+            , @PathVariable Long categoryId, Principal principal
+    ) {
+        String email = PrincipalUtil.toEmail(principal);
+        long cardKeyId = cardKeyService.create(reqDto, categoryId, email);
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED
+                , cardKeyId + "번 카드키 기록 작성");
 
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(rspTemplate);
+    }
     // 목록조회
 
     // 수정
+    @PatchMapping("/card-keys/{cardKeyId}")
+    public RspTemplate<Void> handleUpdateCardKey(
+            @PathVariable Long cardKeyId, @RequestBody @Valid UpdateCardKeyDto.Req reqDto
+    ) {
+        // parcelId 조회, 값 바꿔치기, 저장하기
+        long updatedKeyId = cardKeyService.update(cardKeyId, reqDto);
+
+        return new RspTemplate<>(HttpStatus.OK, updatedKeyId + "번 카드키 기록 수정");
+    }
 
     // 삭제
+    // 민원 삭제
+    @DeleteMapping("/card-keys/{cardKeyId}")
+    public RspTemplate<Void> handleDeleteCardKey(
+            @PathVariable Long cardKeyId
+    ) {
+        long deletedKeyId = cardKeyService.delete(cardKeyId);
 
+        return new RspTemplate<>(HttpStatus.OK, deletedKeyId + "번 카드키 기록 삭제");
+    }
     // 이름검색 (인덱스 만들고, '검색어%' 로 만들 것
+    // 민원 목록 조회. 최신등록순
+    @GetMapping("/categories/{categoryId}/posts/card-key")
+    public RspTemplate<CardKeyListDto.Res> handleGetCardKeys(
+            @PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page
+            , @RequestParam(required = false) String name
+    ) {
+        final int COMPLAINT_TYPE_PAGE_SIZE = 20;
+        Sort sort = Sort.by(Sort.Direction.DESC, "id");
+        Pageable pageable = PageableUtil.of(page, COMPLAINT_TYPE_PAGE_SIZE, sort);
+
+        Category category = categoryService.validateCategoryType(categoryId, Type.CARD_KEY);
+
+        Page<CardKey> cardKeyPage = cardKeyService.getPage(category.getId(), pageable, name);
+
+        CardKeyListDto.Res resDto = CardKeyListDto.Res.from(cardKeyPage, category);
+        return new RspTemplate<>(HttpStatus.OK
+                , "(생성일자 내림차순) 페이지  목록 조회 - " + resDto.getPage().getCurrentPage() + "페이지"
+                ,resDto);
+    }
 
     // 이름검색까지 끝내고 민원대장에 이름
     // 배포하고나서 테스트 오지게 돌리기 싫으면 테스트코드 성공케이스만이라도 일단 작성하자.

--- a/src/main/java/com/dominest/dominestbackend/api/post/cardkey/controller/CardKeyController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/cardkey/controller/CardKeyController.java
@@ -30,7 +30,7 @@ public class CardKeyController {
 
     // 등록
     @PostMapping("/categories/{categoryId}/posts/card-key")
-    public ResponseEntity<RspTemplate<Void>> handleCreateComplaint(
+    public ResponseEntity<RspTemplate<Void>> handleCreateCardKey(
             @RequestBody @Valid CreateCardKeyDto.Req reqDto
             , @PathVariable Long categoryId, Principal principal
     ) {
@@ -43,8 +43,6 @@ public class CardKeyController {
                 .status(HttpStatus.CREATED)
                 .body(rspTemplate);
     }
-    // 목록조회
-
     // 수정
     @PatchMapping("/card-keys/{cardKeyId}")
     public RspTemplate<Void> handleUpdateCardKey(
@@ -57,7 +55,7 @@ public class CardKeyController {
     }
 
     // 삭제
-    // 민원 삭제
+    // 카드키 기록 삭제
     @DeleteMapping("/card-keys/{cardKeyId}")
     public RspTemplate<Void> handleDeleteCardKey(
             @PathVariable Long cardKeyId
@@ -66,8 +64,8 @@ public class CardKeyController {
 
         return new RspTemplate<>(HttpStatus.OK, deletedKeyId + "번 카드키 기록 삭제");
     }
-    // 이름검색 (인덱스 만들고, '검색어%' 로 만들 것
-    // 민원 목록 조회. 최신등록순
+    // 이름검색 (인덱스 만들고, '검색어%' 로 만들 것)
+    // 카드키 목록 조회. 최신등록순
     @GetMapping("/categories/{categoryId}/posts/card-key")
     public RspTemplate<CardKeyListDto.Res> handleGetCardKeys(
             @PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page

--- a/src/main/java/com/dominest/dominestbackend/api/post/cardkey/dto/CardKeyListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/cardkey/dto/CardKeyListDto.java
@@ -1,0 +1,75 @@
+package com.dominest.dominestbackend.api.post.cardkey.dto;
+
+import com.dominest.dominestbackend.api.common.AuditLog;
+import com.dominest.dominestbackend.api.common.CategoryDto;
+import com.dominest.dominestbackend.api.common.PageInfoDto;
+import com.dominest.dominestbackend.domain.post.cardkey.CardKey;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CardKeyListDto {
+
+    @Getter
+    public static class Res {
+        CategoryDto category;
+        PageInfoDto page;
+
+        List<CardKeyDto> cardKeys;
+
+        public static Res from(Page<CardKey> cardKeyPage, Category category) {
+            CategoryDto categoryDto = CategoryDto.from(category);
+            PageInfoDto pageInfoDto = PageInfoDto.from(cardKeyPage);
+
+            List<CardKeyDto> complaints = CardKeyDto.from(cardKeyPage);
+            return new Res(categoryDto, pageInfoDto, complaints);
+        }
+
+        public Res(CategoryDto category, PageInfoDto page, List<CardKeyDto> cardKeys) {
+            this.category = category;
+            this.page = page;
+            this.cardKeys = cardKeys;
+        }
+
+    }
+
+    @Builder
+    @Getter
+    static class CardKeyDto {
+        long id;
+        LocalDate issuedDate; // 카드키 발급일자
+        String roomNo; // N호실
+        String name; // 이름
+        LocalDate dateOfBirth; // 생년월일
+        Integer reIssueCnt; // 재발급 횟수
+
+        String etc;     // 비고
+        AuditLog auditLog; // 여기에 '작성자' 있음.
+
+        static CardKeyDto from(CardKey cardKey){
+            return CardKeyDto.builder()
+                    .id(cardKey.getId())
+                    .issuedDate(cardKey.getIssuedDate())
+                    .roomNo(cardKey.getRoomNo())
+                    .name(cardKey.getName())
+                    .dateOfBirth(cardKey.getDateOfBirth())
+                    .reIssueCnt(cardKey.getReIssueCnt())
+                    .etc(cardKey.getEtc())
+                    .auditLog(AuditLog.from(cardKey))
+                    .build();
+        }
+
+        static List<CardKeyDto> from(Page<CardKey> cardKeyPage){
+            return cardKeyPage
+                    .map(CardKeyDto::from)
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/cardkey/dto/CreateCardKeyDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/cardkey/dto/CreateCardKeyDto.java
@@ -1,0 +1,49 @@
+package com.dominest.dominestbackend.api.post.cardkey.dto;
+
+import com.dominest.dominestbackend.domain.post.cardkey.CardKey;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateCardKeyDto {
+    @NoArgsConstructor
+    @Getter
+    public static class Req {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        @NotNull(message = "카드키 발급일자를 입력해주세요")
+        LocalDate issuedDate; // 카드키 발급일자
+        @NotBlank(message = "기숙사 방 번호를 입력해주세요.")
+        String roomNo; // N호실
+        @NotBlank(message = "이름을 입력해주세요.")
+        String name; // 이름
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate dateOfBirth; // 생년월일
+        @NotNull(message = "재발급 횟수를 입력해주세요.")
+        @PositiveOrZero(message = "재발급 횟수는 0 이상이어야 합니다.")
+        Integer reIssueCnt; // 재발급 횟수
+
+        String etc = ""; // 비고. 검증하지 않고 값이 없으면 EMPTY STRING 처리함.
+
+        public CardKey toEntity(User user, Category category) {
+            return CardKey.builder()
+                    .issuedDate(issuedDate)
+                    .roomNo(roomNo)
+                    .name(name)
+                    .dateOfBirth(dateOfBirth)
+                    .reIssueCnt(reIssueCnt)
+                    .etc(etc)
+                    .writer(user)
+                    .category(category)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/cardkey/dto/UpdateCardKeyDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/cardkey/dto/UpdateCardKeyDto.java
@@ -1,0 +1,33 @@
+package com.dominest.dominestbackend.api.post.cardkey.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateCardKeyDto {
+    @NoArgsConstructor
+    @Getter
+    public static class Req {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        @NotNull(message = "카드키 발급일자를 입력해주세요")
+        LocalDate issuedDate; // 카드키 발급일자
+        @NotBlank(message = "기숙사 방 번호를 입력해주세요.")
+        String roomNo; // N호실
+        @NotBlank(message = "이름을 입력해주세요.")
+        String name; // 이름
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate dateOfBirth; // 생년월일
+        @NotNull(message = "재발급 횟수를 입력해주세요.")
+        @PositiveOrZero(message = "재발급 횟수는 0 이상이어야 합니다.")
+        Integer reIssueCnt; // 재발급 횟수
+
+        String etc = ""; // 비고. 검증하지 않고 값이 없으면 EMPTY STRING 처리함.
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
@@ -66,7 +66,7 @@ public class ComplaintController {
 
     // 민원 목록 조회. 최신등록순
     @GetMapping("/categories/{categoryId}/posts/complaint")
-    public RspTemplate<ComplaintListDto.Res> handleGetParcelPosts(
+    public RspTemplate<ComplaintListDto.Res> handleGetComplaints(
             @PathVariable Long categoryId, @RequestParam(defaultValue = "1") int page
             , @RequestParam(required = false) String roomNoSch
             , @RequestParam(required = false) String complSchText

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/ComplaintListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/ComplaintListDto.java
@@ -45,6 +45,7 @@ public class ComplaintListDto {
     @Getter
     static class ComplaintDto {
         Long id;
+        String name;    //민원인 이름
         LocalDate date; // 민원접수일자
         String roomNo; // 호실
         String complaintCause; // 민원내역. FtIdx 만들어야 함.
@@ -56,6 +57,7 @@ public class ComplaintListDto {
         static ComplaintDto from(Complaint complaint){
             return ComplaintDto.builder()
                     .id(complaint.getId())
+                    .name(complaint.getName())
                     .date(complaint.getDate())
                     .roomNo(complaint.getRoomNo())
                     .complaintCause(complaint.getComplaintCause())

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/CreateComplaintDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/CreateComplaintDto.java
@@ -17,6 +17,8 @@ public class CreateComplaintDto {
     @NoArgsConstructor
     @Getter
     public static class Req {
+        @NotBlank(message = "민원인 이름을 입력해주세요.")
+        private String name;    //민원인 이름
         @NotBlank(message = "기숙사 방 번호를 입력해주세요.")
         private String roomNo; // N호실
 
@@ -33,6 +35,7 @@ public class CreateComplaintDto {
 
         public Complaint toEntity(User user, Category category) {
             return Complaint.builder()
+                    .name(name)
                     .roomNo(roomNo)
                     .complaintCause(complaintCause)
                     .complaintResolution(complaintResolution)

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/UpdateComplaintDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/UpdateComplaintDto.java
@@ -15,6 +15,8 @@ public class UpdateComplaintDto {
     @NoArgsConstructor
     @Getter
     public static class Req {
+        @NotBlank(message = "민원인 이름을 입력해주세요.")
+        private String name;    //민원인 이름
         @NotBlank(message = "기숙사 방 번호를 입력해주세요.")
         private String roomNo; // N호실
 

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKey.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKey.java
@@ -18,6 +18,10 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(
+        indexes =
+        @Index(name = "idx_card_key_name", columnList = "name")
+)
 public class CardKey extends BaseEntity {
 
     @Id
@@ -30,7 +34,7 @@ public class CardKey extends BaseEntity {
     private String roomNo; // 호실
 
     @Column(nullable = false)
-    private String name; // 이름
+    private String name; // 소유자 이름
     @Column(nullable = false)
     private LocalDate dateOfBirth; // 생년월일
 

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKey.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKey.java
@@ -1,0 +1,70 @@
+package com.dominest.dominestbackend.domain.post.cardkey;
+
+import com.dominest.dominestbackend.domain.common.BaseEntity;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+/**
+ * 카드키 관리대장 페이지에서 쓰일 카드키 관리 엔티티
+ * 객체 하나가 페이지상의 한 행에 대응됨.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class CardKey extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate issuedDate; // 카드키 발급날짜
+    @Column(nullable = false)
+    private String roomNo; // 호실
+
+    @Column(nullable = false)
+    private String name; // 이름
+    @Column(nullable = false)
+    private LocalDate dateOfBirth; // 생년월일
+
+    @Column(nullable = false)
+    private Integer reIssueCnt; // 재발급 횟수
+
+    @Column(nullable = false)
+    private String etc = ""; // 비고
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "writer_id")
+    private User writer;    // 작성자 정보
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "category_id")
+    private Category category;
+
+    @Builder
+    private CardKey(LocalDate issuedDate, String roomNo, String name, LocalDate dateOfBirth, Integer reIssueCnt, String etc, User writer, Category category) {
+        this.issuedDate = issuedDate;
+        this.roomNo = roomNo;
+        this.name = name;
+        this.dateOfBirth = dateOfBirth;
+        this.reIssueCnt = reIssueCnt;
+        this.etc = etc;
+        this.writer = writer;
+        this.category = category;
+    }
+
+    public void updateValues(LocalDate issuedDate, String roomNo, String name, LocalDate dateOfBirth, Integer reIssueCnt, String etc) {
+        this.issuedDate = issuedDate;
+        this.roomNo = roomNo;
+        this.name = name;
+        this.dateOfBirth = dateOfBirth;
+        this.reIssueCnt = reIssueCnt;
+        this.etc = etc;
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyRepository.java
@@ -1,6 +1,11 @@
 package com.dominest.dominestbackend.domain.post.cardkey;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardKeyRepository extends JpaRepository<CardKey, Long> {
+    Page<CardKey> findAllByCategoryIdAndNameStartsWith(Long id, String name, Pageable pageable);
+
+    Page<CardKey> findAllByCategoryId(Long id, Pageable pageable);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyRepository.java
@@ -3,9 +3,15 @@ package com.dominest.dominestbackend.domain.post.cardkey;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CardKeyRepository extends JpaRepository<CardKey, Long> {
-    Page<CardKey> findAllByCategoryIdAndNameStartsWith(Long id, String name, Pageable pageable);
+    @Query(value = "SELECT c FROM CardKey c" +
+            " WHERE c.category.id = :categoryId AND c.name LIKE CONCAT(:name, '%')")
+    Page<CardKey> findAllByCategoryIdAndNameStartsWith(@Param("categoryId") Long categoryId, @Param("name") String name, Pageable pageable);
 
-    Page<CardKey> findAllByCategoryId(Long id, Pageable pageable);
+    @Query(value = "SELECT c FROM CardKey c" +
+                " WHERE c.category.id = :categoryId")
+    Page<CardKey> findAllByCategoryId(@Param("categoryId") Long id, Pageable pageable);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyRepository.java
@@ -1,0 +1,6 @@
+package com.dominest.dominestbackend.domain.post.cardkey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardKeyRepository extends JpaRepository<CardKey, Long> {
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyService.java
@@ -2,6 +2,13 @@ package com.dominest.dominestbackend.domain.post.cardkey;
 
 import com.dominest.dominestbackend.api.post.cardkey.dto.CreateCardKeyDto;
 import com.dominest.dominestbackend.api.post.cardkey.dto.UpdateCardKeyDto;
+import com.dominest.dominestbackend.domain.post.component.category.Category;
+import com.dominest.dominestbackend.domain.post.component.category.component.Type;
+import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
+import com.dominest.dominestbackend.domain.user.User;
+import com.dominest.dominestbackend.domain.user.service.UserService;
+import com.dominest.dominestbackend.global.exception.ErrorCode;
+import com.dominest.dominestbackend.global.util.EntityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,20 +21,47 @@ import org.springframework.util.StringUtils;
 @Service
 public class CardKeyService {
     private final CardKeyRepository cardKeyRepository;
+    private final UserService userService;
+    private final CategoryService categoryService;
 
     @Transactional
     public long create(CreateCardKeyDto.Req reqDto, Long categoryId, String email) {
-        return 0;
+        // CardKey 연관 객체인 category, user 찾기
+        User user = userService.getUserByEmail(email);
+        // CardKey 연관 객체인 category 찾기
+        Category category = categoryService.validateCategoryType(categoryId, Type.CARD_KEY);
+
+        CardKey cardKey = reqDto.toEntity(user, category);
+
+        // CardKey 객체 생성 후 저장
+        return cardKeyRepository.save(cardKey).getId();
     }
 
     @Transactional
     public long update(Long cardKeyId, UpdateCardKeyDto.Req reqDto) {
-        return 0;
+        CardKey cardKey = getById(cardKeyId);
+
+        cardKey.updateValues(
+                reqDto.getIssuedDate()
+                , reqDto.getRoomNo()
+                , reqDto.getName()
+                , reqDto.getDateOfBirth()
+                , reqDto.getReIssueCnt()
+                , reqDto.getEtc()
+        );
+        return cardKey.getId();
+    }
+
+    public CardKey getById(Long id) {
+        return EntityUtil.mustNotNull(cardKeyRepository.findById(id), ErrorCode.CARD_KEY_NOT_FOUND);
     }
 
     @Transactional
-    public long delete(Long cardKeyId) {
-        return 0;
+    public long delete(Long id) {
+        CardKey cardKey = getById(id);
+        cardKeyRepository.delete(cardKey);
+
+        return cardKey.getId();
     }
 
     public Page<CardKey> getPage(Long id, Pageable pageable, String name) {

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyService.java
@@ -1,12 +1,39 @@
 package com.dominest.dominestbackend.domain.post.cardkey;
 
+import com.dominest.dominestbackend.api.post.cardkey.dto.CreateCardKeyDto;
+import com.dominest.dominestbackend.api.post.cardkey.dto.UpdateCardKeyDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class CardKeyService {
     private final CardKeyRepository cardKeyRepository;
+
+    @Transactional
+    public long create(CreateCardKeyDto.Req reqDto, Long categoryId, String email) {
+        return 0;
+    }
+
+    @Transactional
+    public long update(Long cardKeyId, UpdateCardKeyDto.Req reqDto) {
+        return 0;
+    }
+
+    @Transactional
+    public long delete(Long cardKeyId) {
+        return 0;
+    }
+
+    public Page<CardKey> getPage(Long id, Pageable pageable, String name) {
+        if (StringUtils.hasText(name)) {
+            return cardKeyRepository.findAllByCategoryIdAndNameStartsWith(id, name, pageable);
+        }
+        return cardKeyRepository.findAllByCategoryId(id, pageable);
+    }
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/cardkey/CardKeyService.java
@@ -1,0 +1,12 @@
+package com.dominest.dominestbackend.domain.post.cardkey;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CardKeyService {
+    private final CardKeyRepository cardKeyRepository;
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -19,6 +19,8 @@ public class Complaint extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    private String name;    //민원인 이름
+    @Column(nullable = false)
     private String roomNo; // 호실
     @Column(nullable = false)
     private String complaintCause; // 민원내역. FtIdx 만들어야 함.
@@ -42,7 +44,8 @@ public class Complaint extends BaseEntity {
     private Category category;
 
     @Builder
-    private Complaint(String roomNo, String complaintCause, String complaintResolution, ProcessState processState, LocalDate date, User writer, Category category) {
+    private Complaint(String name, String roomNo, String complaintCause, String complaintResolution, ProcessState processState, LocalDate date, User writer, Category category) {
+        this.name = name;
         this.roomNo = roomNo;
         this.complaintCause = complaintCause;
         this.complaintResolution = complaintResolution;
@@ -52,7 +55,8 @@ public class Complaint extends BaseEntity {
         this.category = category;
     }
 
-    public void updateValues(String roomNo, String complaintCause, String complaintResolution, ProcessState processState, LocalDate date) {
+    public void updateValues(String name, String roomNo, String complaintCause, String complaintResolution, ProcessState processState, LocalDate date) {
+        this.name = name;
         this.roomNo = roomNo;
         this.complaintCause = complaintCause;
         this.complaintResolution = complaintResolution;

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -56,8 +56,8 @@ public class ComplaintService {
     }
 
     @Transactional
-    public long delete(Long complaintId) {
-        Complaint complaint = getById(complaintId);
+    public long delete(Long id) {
+        Complaint complaint = getById(id);
         complaintRepository.delete(complaint);
         return complaint.getId();
     }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -10,14 +10,11 @@ import com.dominest.dominestbackend.domain.user.service.UserService;
 import com.dominest.dominestbackend.global.exception.ErrorCode;
 import com.dominest.dominestbackend.global.util.EntityUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-
-import javax.persistence.EntityManager;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,14 +23,6 @@ public class ComplaintService {
     private final ComplaintRepository complaintRepository;
     private final UserService userService;
     private final CategoryService categoryService;
-
-    private EntityManager em;
-
-    @Autowired
-    public void setEm(EntityManager em) {
-        this.em = em;
-    }
-
 
     @Transactional
     public long create(CreateComplaintDto.Req reqDto, Long categoryId, String email) {

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -42,7 +42,8 @@ public class ComplaintService {
         Complaint complaint = getById(complaintId);
 
         complaint.updateValues(
-                reqDto.getRoomNo()
+                reqDto.getName()
+                , reqDto.getRoomNo()
                 , reqDto.getComplaintCause()
                 , reqDto.getComplaintResolution()
                 , reqDto.getProcessState()

--- a/src/main/java/com/dominest/dominestbackend/domain/post/component/category/component/Type.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/component/category/component/Type.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @Getter
 public enum Type {
     IMAGE("image-types"), TEXT_IMAGE("text-image-types")
-    , UNDELIVERED_PARCEL_REGISTER("undelivered-parcel")
-    , COMPLAINT("complaint")
+    , UNDELIVERED_PARCEL_REGISTER("undelivered-parcel") // 장기 미수령 택배 관리대장
+    , COMPLAINT("complaint") // 민원처리내역
+    , CARD_KEY("card-key") // 카드키관리대장
     ;
 
     private final String url;

--- a/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/dominest/dominestbackend/global/exception/ErrorCode.java
@@ -65,7 +65,7 @@ public enum ErrorCode {
 
     // 민원내역
     COMPLAINT_NOT_FOUND(404, "해당 민원이 존재하지 않습니다."),
-    ;
+    CARD_KEY_NOT_FOUND(404, "카드키를 찾을 수 없습니다.");
 
 
 

--- a/src/main/java/com/dominest/dominestbackend/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dominest/dominestbackend/global/exception/handler/GlobalExceptionHandler.java
@@ -66,6 +66,7 @@ public class GlobalExceptionHandler {
         return createErrorResponse(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
+    // ENUM 변환실패, 날짜타입에 2999-15-99 와 같은 잘못된 값이 들어올 때 발생
     @ExceptionHandler({HttpMessageNotReadableException.class})
     public ResponseEntity<ErrorResponseDto<String>> handleInvalidFormatException(HttpMessageNotReadableException e, HttpServletRequest request){
         printLog(e, request);

--- a/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
@@ -85,6 +85,14 @@ public class InitDB {
                 .orderKey(2)
                 .build();
         categoryRepository.save(category2);
+
+        Category category3 = Category.builder()
+                .name("카드키관리대장1")
+                .type(Type.CARD_KEY)
+                .explanation("카키관1")
+                .orderKey(3)
+                .build();
+        categoryRepository.save(category3);
         
         UndeliveredParcelPost unDeliParcelPost = UndeliveredParcelPost.builder()
                 .titleWithCurrentDate(createTitle())
@@ -157,7 +165,7 @@ public class InitDB {
                     .processState(Complaint.ProcessState.PROCESSING)
                     .date(LocalDate.now())
                     .writer(user)
-                    .category(category2)
+                    .category(category3)
                     .build();
             complaints.add(complaint);
         }

--- a/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
@@ -162,6 +162,7 @@ public class InitDB {
         int complaintCount = 23;
         for (int i = 1; i <= complaintCount; i++) {
             Complaint complaint = Complaint.builder()
+                    .name("고세구먼트" + i)
                     .roomNo("101")
                     .complaintCause("난방 불가")
                     .complaintResolution("난방 수으리 완무료")

--- a/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/InitDB.java
@@ -3,6 +3,8 @@ package com.dominest.dominestbackend.global.util;
 
 import com.dominest.dominestbackend.domain.favorite.Favorite;
 import com.dominest.dominestbackend.domain.favorite.FavoriteRepository;
+import com.dominest.dominestbackend.domain.post.cardkey.CardKey;
+import com.dominest.dominestbackend.domain.post.cardkey.CardKeyRepository;
 import com.dominest.dominestbackend.domain.post.complaint.Complaint;
 import com.dominest.dominestbackend.domain.post.complaint.ComplaintRepository;
 import com.dominest.dominestbackend.domain.post.component.category.Category;
@@ -39,6 +41,7 @@ public class InitDB {
     private final UndeliveredParcelPostRepository undelivParcelPostRepository;
     private final UndeliveredParcelRepository undelivParcelRepository;
     private final ComplaintRepository complaintRepository;
+    private final CardKeyRepository cardKeyRepository;
 
     @Transactional
     @PostConstruct
@@ -70,33 +73,33 @@ public class InitDB {
         userRepository.save(user3);
 
 
-        Category category1 = Category.builder()
-                .name("장기 미수령 택배 관리대장")
+        Category undelivCategoryNo1 = Category.builder()
+                .name("장기 미수령 택배 관리대장1")
                 .type(Type.UNDELIVERED_PARCEL_REGISTER)
-                .explanation("장미택관")
+                .explanation("장미택관1")
                 .orderKey(1)
                 .build();
-        categoryRepository.save(category1);
+        categoryRepository.save(undelivCategoryNo1);
 
-        Category category2 = Category.builder()
-                .name("민원처리내역")
+        Category complaintCategoryNO2 = Category.builder()
+                .name("민원접수내역1")
                 .type(Type.COMPLAINT)
-                .explanation("민처내")
+                .explanation("민접내")
                 .orderKey(2)
                 .build();
-        categoryRepository.save(category2);
+        categoryRepository.save(complaintCategoryNO2);
 
-        Category category3 = Category.builder()
+        Category cardKeyCategoryNO3 = Category.builder()
                 .name("카드키관리대장1")
                 .type(Type.CARD_KEY)
                 .explanation("카키관1")
                 .orderKey(3)
                 .build();
-        categoryRepository.save(category3);
+        categoryRepository.save(cardKeyCategoryNO3);
         
         UndeliveredParcelPost unDeliParcelPost = UndeliveredParcelPost.builder()
                 .titleWithCurrentDate(createTitle())
-                .category(category1)
+                .category(undelivCategoryNo1)
                 .writer(user)
                 .build();
         undelivParcelPostRepository.save(unDeliParcelPost);
@@ -139,7 +142,7 @@ public class InitDB {
             ImageType imageType = ImageType.builder()
                     .title("title" + i)
                     .writer(user)
-                    .category(categories.get(2)) // 3번 카테고리
+                    .category(categories.get(2)) // 3번째 카테고리
                     .build();
             imageTypes.add(imageType);
         }
@@ -165,11 +168,28 @@ public class InitDB {
                     .processState(Complaint.ProcessState.PROCESSING)
                     .date(LocalDate.now())
                     .writer(user)
-                    .category(category3)
+                    .category(complaintCategoryNO2) // 민원접수내역
                     .build();
             complaints.add(complaint);
         }
         complaintRepository.saveAll(complaints);
+
+        ArrayList<CardKey> cardKeys = new ArrayList<>();
+        int cardKeyCount = 23;
+        for (int i = 1; i <= cardKeyCount; i++) {
+            CardKey cardKey = CardKey.builder()
+                    .issuedDate(LocalDate.now())
+                    .roomNo("10" + i)
+                    .name("송승헌" + i)
+                    .dateOfBirth(LocalDate.of(1999, 1, i))
+                    .reIssueCnt(i)
+                    .etc(i + "번 안아줘요")
+                    .writer(user)
+                    .category(cardKeyCategoryNO3)
+                    .build();
+            cardKeys.add(cardKey);
+        }
+        cardKeyRepository.saveAll(cardKeys);
     }
     private String createTitle() {
         // 원하는 형식의 문자열로 변환


### PR DESCRIPTION
## 요약
- Cardkey CRUD 기능 추가 (등록, 삭제, 수정, 목록조회(이름으로 검색))
- 민원신청내역 '이름' 속성 추가

## 추가사항

**CardKeyController**
- @PostMapping("/categories/{categoryId}/posts/card-key") // 등록 
- @GetMapping("/categories/{categoryId}/posts/card-key") // 목록조회. ?name=...&page=3 검색 가능.
- @DeleteMapping("/card-keys/{cardKeyId}") // 삭제
- @PatchMapping("/card-keys/{cardKeyId}") // 수정

## 수정사항
- 민원신청내역에 '이름' (민원인 이름) 속성 추가
