### PR TITLE
feat: 월별 스케줄 가져오기 로직 추가

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/calendar/controller/CalenderController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/calendar/controller/CalenderController.java
@@ -1,6 +1,7 @@
 package com.dominest.dominestbackend.api.calendar.controller;
 
 import com.dominest.dominestbackend.api.calendar.request.CalenderSaveRequest;
+import com.dominest.dominestbackend.api.calendar.response.CalendarMonthResponse;
 import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.domain.calender.Calender;
 import com.dominest.dominestbackend.domain.calender.service.CalenderService;
@@ -22,8 +23,13 @@ public class CalenderController {
     }
 
     @GetMapping("/get/{date}") // 날짜 들어오면 일정 내보내기 없을 때 처리
-    public List<Calender> getEventsByDate(@PathVariable("date") String dateString) {
+    public RspTemplate<List<Calender>> getEventsByDate(@PathVariable("date") String dateString) {
         return calenderService.getByDate(dateString);
+    }
+
+    @GetMapping("/list/{date}") // 날짜 들어오면 일정 내보내기 없을 때 처리
+    public RspTemplate<List<CalendarMonthResponse>> getEventsByMonth(@PathVariable("date") String dateString) {
+        return calenderService.getByMonth(dateString);
     }
 
     @DeleteMapping("/delete/{date}")

--- a/src/main/java/com/dominest/dominestbackend/api/calendar/response/CalendarMonthResponse.java
+++ b/src/main/java/com/dominest/dominestbackend/api/calendar/response/CalendarMonthResponse.java
@@ -1,0 +1,14 @@
+package com.dominest.dominestbackend.api.calendar.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CalendarMonthResponse {
+    private int id;
+    private boolean content; // 내용 유무
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/calender/service/CalenderService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/calender/service/CalenderService.java
@@ -1,6 +1,7 @@
 package com.dominest.dominestbackend.domain.calender.service;
 
 import com.dominest.dominestbackend.api.calendar.request.CalenderSaveRequest;
+import com.dominest.dominestbackend.api.calendar.response.CalendarMonthResponse;
 import com.dominest.dominestbackend.api.common.RspTemplate;
 import com.dominest.dominestbackend.domain.calender.Calender;
 import com.dominest.dominestbackend.domain.calender.repository.CalenderRepository;
@@ -8,14 +9,12 @@ import com.dominest.dominestbackend.global.exception.ErrorCode;
 import com.dominest.dominestbackend.global.exception.exceptions.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -40,19 +39,31 @@ public class CalenderService {
         }
     }
 
-    public List<Calender> getByDate(String dateString) {
-        try {
-            LocalDate date = LocalDate.parse(dateString);
-            List<Calender> events = calenderRepository.findByDate(date);
-//            if(events.isEmpty()){
-//                throw new BusinessException(ErrorCode.DATA_NOT_FOUND);
-//            }
+    public RspTemplate<List<Calender>> getByDate(String dateString) {
+        LocalDate date = LocalDate.parse(dateString);
+        List<Calender> events = calenderRepository.findByDate(date);
 
-            return events;
-        } catch (Exception e) {
-            throw new BusinessException(ErrorCode.DATA_NOT_FOUND);
-        }
+        return new RspTemplate<>(HttpStatus.OK, dateString +"의 일정을 성공적으로 가져왔습니다.", events);
+
+        // 해당 날짜에 대한 일정이 없을 때는 빈 리스트 반환하도록 에러 처리 X
     }
+
+    /*- 월별 일정 가져오기 -------*/
+    public RspTemplate<List<CalendarMonthResponse>> getByMonth(String dateString) {
+        YearMonth yearMonth = YearMonth.parse(dateString);
+        int daysInMonth = yearMonth.lengthOfMonth();
+        List<CalendarMonthResponse> events = new ArrayList<>();
+
+        for (int day = 1; day <= daysInMonth; day++) {
+            LocalDate date = LocalDate.of(yearMonth.getYear(), yearMonth.getMonthValue(), day);
+            List<Calender> dailyEvents = calenderRepository.findByDate(date);
+            boolean hasEvents = !dailyEvents.isEmpty();
+            events.add(new CalendarMonthResponse(day, hasEvents));
+        }
+
+        return new RspTemplate<>(HttpStatus.OK, dateString +"의 일정을 성공적으로 가져왔습니다.", events);
+    }
+
 
     @Transactional
     public RspTemplate<String> deleteEventsByDate(String dateString) {

--- a/src/main/java/com/dominest/dominestbackend/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/schedule/service/ScheduleService.java
@@ -27,15 +27,11 @@ public class ScheduleService {
     public void saveSchedule(ScheduleSaveRequest requests) {
         List<String> usernames = requests.getUsernames();
 
-        try{
-            Schedule schedule = scheduleRepository.findByDayOfWeekAndTimeSlot(requests.getDayOfWeek(), requests.getTimeSlot()).get(0);
+        Schedule schedule = scheduleRepository.findByDayOfWeekAndTimeSlot(requests.getDayOfWeek(), requests.getTimeSlot()).get(0);
 
-            schedule.getUsernames().addAll(usernames);
+        schedule.getUsernames().addAll(usernames);
 
-            scheduleRepository.save(schedule);
-        } catch (Exception e){
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+        scheduleRepository.save(schedule);
     }
 
     public List<Map<String, Object>> getSchedule() {


### PR DESCRIPTION
## 요약
- 월별 스케줄을 가져오는 로직 추가

## 추가사항
- 2023-10-24 처럼 날짜로만 조회가 가능했었는데, 2023-10 처럼 월 까지 작성하여 요청을 보내면 1일 ~ 31일까지 일정이 존재한다면 true, 없다면 false를 반환하는 로직을 추가하였습니다. id는 1부터 31일까지 for문을 돌며 자동 생성되며 id는 일(day)를 나타냅니다. content는 boolean 타입으로 예슬님의 요청대로 일정이 존재한다면 true, 없다면 false를 반환하도록 작성하였습니다.

## 수정사항
- X!!
