### PR TITLE
민원처리내역 엑셀 다운로드기능과 FileService 관련 리팩토링

### DIFF
--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
@@ -118,7 +118,7 @@ public class ComplaintController {
         }
         String sheetName = "민원접수내역";
 
-        ExcelUtil.createAndRespondComplaintData(filename, sheetName, response, complaints);
+        ExcelUtil.createAndRespondAllDataWitehComplaint(filename, sheetName, response, complaints);
     }
 
 }

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/controller/ComplaintController.java
@@ -11,6 +11,7 @@ import com.dominest.dominestbackend.domain.post.component.category.Category;
 import com.dominest.dominestbackend.domain.post.component.category.component.Type;
 import com.dominest.dominestbackend.domain.post.component.category.service.CategoryService;
 import com.dominest.dominestbackend.global.util.ExcelUtil;
+import com.dominest.dominestbackend.global.util.FileService;
 import com.dominest.dominestbackend.global.util.PageableUtil;
 import com.dominest.dominestbackend.global.util.PrincipalUtil;
 import lombok.RequiredArgsConstructor;
@@ -107,14 +108,24 @@ public class ComplaintController {
         String filename;
         LocalDate now = LocalDate.now();
         String formattedDate = now.format(DateTimeFormatter.ofPattern("yy-MM-dd"));
+        StringBuilder sb = new StringBuilder();
         if (downloadCnt == null) {
             complaints = complaintRepository.findAllByCategoryId(category.getId(), Sort.by(Order.desc("id")));
-            filename = formattedDate + " 민원접수내역 전체 " + complaintCnt +  "건.xlsx";
+            filename = sb.append(formattedDate)
+                    .append(" 민원접수내역 전체 ")
+                    .append(complaintCnt).append("건")
+                    .append(".").append(FileService.FileExt.XLSX.value)
+                    .toString();
         } else {
-            complaints = complaintRepository.findAllByCategoryId(category.getId(),
+            complaints = complaintRepository.findAllByCategoryId(
+                    category.getId(),
                     PageableUtil.of(1, downloadCnt)
             );
-            filename = formattedDate + " 민원접수내역 최신 " + downloadCnt +  "건.xlsx";
+            filename = sb.append(formattedDate)
+                    .append(" 민원접수내역 최신 ")
+                    .append(downloadCnt).append("건")
+                    .append(".").append(FileService.FileExt.XLSX.value)
+                    .toString();
         }
         String sheetName = "민원접수내역";
 

--- a/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/ComplaintListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/complaint/dto/ComplaintListDto.java
@@ -68,9 +68,9 @@ public class ComplaintListDto {
         }
 
         static List<ComplaintDto> from(Page<Complaint> complaints){
-            return complaints.stream()
+            return complaints
                     .map(ComplaintDto::from)
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/api/post/image/dto/ImageTypeListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/image/dto/ImageTypeListDto.java
@@ -57,9 +57,9 @@ public class ImageTypeListDto {
             }
 
             static List<ImageTypeDto> from(Page<ImageType> imageTypes){
-                return imageTypes.stream()
+                return imageTypes
                         .map(ImageTypeDto::from)
-                        .collect(Collectors.toList());
+                        .toList();
             }
         }
     }

--- a/src/main/java/com/dominest/dominestbackend/api/post/sanitationcheck/controller/SanitationCheckController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/sanitationcheck/controller/SanitationCheckController.java
@@ -17,6 +17,7 @@ import com.dominest.dominestbackend.domain.post.sanitationcheck.floor.checkedroo
 import com.dominest.dominestbackend.domain.post.sanitationcheck.floor.checkedroom.CheckedRoomService;
 import com.dominest.dominestbackend.domain.resident.component.ResidenceSemester;
 import com.dominest.dominestbackend.global.util.ExcelUtil;
+import com.dominest.dominestbackend.global.util.FileService.FileExt;
 import com.dominest.dominestbackend.global.util.PageableUtil;
 import com.dominest.dominestbackend.global.util.PrincipalUtil;
 import lombok.Getter;
@@ -192,7 +193,7 @@ public class SanitationCheckController {
     ) {
         String postTitle = sanitationCheckPostService.getById(postId).getTitle();
 
-        String filename = postTitle + " - 벌점 부여자 명단" + ".xlsx";
+        String filename = postTitle + " - 벌점 부여자 명단" + "." + FileExt.XLSX.value;
         String sheetName = "벌점 부여자 명단";
 
         // N차 통과를 조회하려면 CheckedRoom까지 조회해야 함. Resident를 Inner Join해서 빈 방 조회를 피하자.
@@ -214,7 +215,7 @@ public class SanitationCheckController {
         String postTitle = sanitationCheckPostService.getById(postId).getTitle();
 
         String passStateValue = passState.getValue();
-        String filename = postTitle + " - " + passStateValue + " 명단" + ".xlsx";
+        String filename = postTitle + " - " + passStateValue + " 명단" + "." + FileExt.XLSX.value;
         String sheetName = passStateValue + "명단";
 
         // N차 통과를 조회하려면 CheckedRoom까지 조회해야 함. Resident를 Inner Join해서 빈 방 조회를 피하자.
@@ -232,7 +233,7 @@ public class SanitationCheckController {
     ) {
         String postTitle = sanitationCheckPostService.getById(postId).getTitle();
 
-        String filename = postTitle + " - 점검표 전체 데이터" + ".xlsx";
+        String filename = postTitle + " - 점검표 전체 데이터" + "." + FileExt.XLSX.value;
         String sheetName = "점검표 전체 데이터";
 
         // N차 통과를 조회하려면 CheckedRoom까지 조회해야 함. Resident를 Inner Join해서 빈 방 조회를 피하자.

--- a/src/main/java/com/dominest/dominestbackend/api/post/sanitationcheck/controller/SanitationCheckController.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/sanitationcheck/controller/SanitationCheckController.java
@@ -202,7 +202,7 @@ public class SanitationCheckController {
         List<CheckedRoom> checkedRoomsGotPenalty = checkedRoomRepository.findAllByPostIdAndNotInPassState(postId, penalty0passStates);
 
         // 파일 이름 설정
-        ExcelUtil.createAndRespondCheckedRoomData(filename, sheetName, response, checkedRoomsGotPenalty);
+        ExcelUtil.createAndRespondResidentInfoWithCheckedRoom(filename, sheetName, response, checkedRoomsGotPenalty);
     }
 
     // (엑셀 다운로드) 방호점 게시글의 특정 통과차수에 해당하는 입사생 목록
@@ -222,7 +222,7 @@ public class SanitationCheckController {
         List<CheckedRoom> checkedRooms = checkedRoomRepository.findAllByPostIdAndPassState(postId, passState);
 
         // 파일 이름 설정
-        ExcelUtil.createAndRespondCheckedRoomData(filename, sheetName, response, checkedRooms);
+        ExcelUtil.createAndRespondResidentInfoWithCheckedRoom(filename, sheetName, response, checkedRooms);
     }
 
     // (엑셀 다운로드) 방호점 게시글의 전체 데이터
@@ -239,7 +239,7 @@ public class SanitationCheckController {
         List<CheckedRoom> checkedRoomsGotPenalty = checkedRoomRepository.findAllByPostId(postId);
 
         // 파일 이름 설정
-        ExcelUtil.createAndRespondAllCheckedRoomData(filename, sheetName, response, checkedRoomsGotPenalty);
+        ExcelUtil.createAndRespondAllDataWithCheckedRoom(filename, sheetName, response, checkedRoomsGotPenalty);
     }
 
 

--- a/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/dto/UndelivParcelPostListDto.java
+++ b/src/main/java/com/dominest/dominestbackend/api/post/undeliveredparcel/dto/UndelivParcelPostListDto.java
@@ -55,9 +55,9 @@ public class UndelivParcelPostListDto {
             }
 
             static List<UndelivParcelPostDto> from(Page<UndeliveredParcelPost> posts){
-                return posts.stream()
+                return posts
                         .map(UndelivParcelPostDto::from)
-                        .collect(Collectors.toList());
+                        .toList();
             }
         }
     }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -32,7 +32,7 @@ public class Complaint extends BaseEntity {
     private ProcessState processState; // 처리상태
 
     @Column(nullable = false)
-    private LocalDate date; // 민원접수일자
+    private LocalDate date; // 민원접수일자. 사용자 요청에 의한 DB 등록시간(createTime)과 실제 접수일이 다를 수 있음.
 
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/Complaint.java
@@ -72,6 +72,6 @@ public class Complaint extends BaseEntity {
         RECEIPT_COMPLETED("접수완료"), PROCESSING("처리중"), PROCESS_COMPLETED("처리완료");
 
         @JsonValue // 직렬화, 역직렬화 시 사용될 값
-        private final String state;
+        public final String state;
     }
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintRepository.java
@@ -2,9 +2,12 @@ package com.dominest.dominestbackend.domain.post.complaint;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
 
@@ -13,7 +16,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
 
             , countQuery = "SELECT count(c) FROM Complaint c WHERE c.category.id = :categoryId"
     )
-    Page<Complaint> findAllByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
+    Page<Complaint> findPageAllByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
     @Query(nativeQuery = true,
             value = "SELECT * FROM complaint c" +
@@ -31,4 +34,8 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     Page<Complaint> findAllByCategoryIdAndRoomNo(@Param("categoryId") Long categoryId, @Param("roomNoSch") String roomNoSch, Pageable pageable);
 
     void deleteByCategoryId(Long categoryId);
+
+    List<Complaint> findAllByCategoryId(Long categoryId, Pageable pageable);
+    List<Complaint> findAllByCategoryId(Long categoryId, Sort sort);
+    long countByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -88,12 +88,6 @@ public class ComplaintService {
         }
         return complaintRepository.findPageAllByCategoryId(categoryId, pageable);
     }
-
-    public List<Complaint> getPage(Long categoryId, Pageable pageable) {
-        return complaintRepository.findAllByCategoryId(categoryId, pageable);
-    }
-
-
 }
 
 

--- a/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/post/complaint/ComplaintService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -84,6 +86,10 @@ public class ComplaintService {
         if (StringUtils.hasText(complSchText)) {
             return complaintRepository.findAllByCategoryIdSearch(categoryId, complSchText + "*", pageable);
         }
+        return complaintRepository.findPageAllByCategoryId(categoryId, pageable);
+    }
+
+    public List<Complaint> getPage(Long categoryId, Pageable pageable) {
         return complaintRepository.findAllByCategoryId(categoryId, pageable);
     }
 

--- a/src/main/java/com/dominest/dominestbackend/domain/resident/Resident.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/resident/Resident.java
@@ -10,6 +10,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -182,6 +183,10 @@ public class Resident extends BaseEntity {
             throw new IllegalArgumentException("전화번호 형식이 잘못되었습니다.");
         String lastFourDigits = splitedNumber[splitedNumber.length - 1]; // 마지막 4자리 숫자
         this.name = name + "(" + lastFourDigits + ")";
+    }
+
+    public String generatePdfFileNameToStore() {
+        return this.name + "-" + UUID.randomUUID() + ".pdf";
     }
 
 }

--- a/src/main/java/com/dominest/dominestbackend/domain/resident/ResidentFileManager.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/resident/ResidentFileManager.java
@@ -1,0 +1,37 @@
+package com.dominest.dominestbackend.domain.resident;
+
+import com.dominest.dominestbackend.global.exception.exceptions.BusinessException;
+import com.dominest.dominestbackend.global.util.FileService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import static com.dominest.dominestbackend.global.util.FileService.FilePrefix.RESIDENT_ADMISSION;
+import static com.dominest.dominestbackend.global.util.FileService.FilePrefix.RESIDENT_DEPARTURE;
+
+/**
+ * Resident와 File 관련 로직을 중개하는 클래스
+ */
+@Service
+public class ResidentFileManager {
+    // FilePrefix (파일 타입) 에 맞게 파일명을 등록한다.
+    public void setPdfFilenameToResident(Resident resident, FileService.FilePrefix filePrefix, String uploadedFilename) {
+        if (filePrefix.equals(RESIDENT_ADMISSION)) {
+            resident.setAdmissionPdfFileName(uploadedFilename);
+        } else if (filePrefix.equals(RESIDENT_DEPARTURE)) {
+            resident.setDeparturePdfFileName(uploadedFilename);
+        } else { // 입사신청서, 퇴사신청서가 아닌 다른 FilePrefix 값일 때
+            throw new BusinessException("잘못된 FilePrefix 값입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // FilePrefix (파일 타입) 에 맞는 파일명을 가져온다.
+    public String getPdfFilename(Resident resident, FileService.FilePrefix filePrefix) {
+        if (filePrefix.equals(RESIDENT_ADMISSION)) {
+            return resident.getAdmissionPdfFileName();
+        } else if (filePrefix.equals(RESIDENT_DEPARTURE)) {
+            return resident.getDeparturePdfFileName();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/dominest/dominestbackend/domain/resident/ResidentService.java
+++ b/src/main/java/com/dominest/dominestbackend/domain/resident/ResidentService.java
@@ -31,6 +31,7 @@ public class ResidentService {
     private final ResidentRepository residentRepository;
     private final FileService fileService;
     private final RoomService roomService;
+    private final ResidentFileManager residentFileManager;
 
     /** @return 저장한 파일명 */
     @Transactional
@@ -43,11 +44,11 @@ public class ResidentService {
 
         String uploadedFilename = fileService.save(filePrefix, pdf, resident.generatePdfFileNameToStore());
 
-        String prevFileName = filePrefix.getPdfFileName(resident);
-        filePrefix.setPdfFileNameToResident(resident, uploadedFilename);
+        String prevFilename = residentFileManager.getPdfFilename(resident, filePrefix);
+        residentFileManager.setPdfFilenameToResident(resident, filePrefix, uploadedFilename);
 
-        if (prevFileName != null)
-            fileService.deleteFile(filePrefix, prevFileName);
+        if (prevFilename != null)
+            fileService.deleteFile(filePrefix, prevFilename);
     }
 
     @Transactional
@@ -61,7 +62,7 @@ public class ResidentService {
 
             String filename = pdf.getOriginalFilename();
             // pdf 확장자가 아니라면 continue
-            if (fileService.isInvalidFileExtension(filename, FileService.FileExt.PDF)){
+            if (fileService.isInvalidFileExtension(filename, FileService.FileExt.PDF)) {
                 continue;
             }
 
@@ -77,16 +78,14 @@ public class ResidentService {
 
             String uploadedFilename = fileService.save(filePrefix, pdf, resident.generatePdfFileNameToStore());
 
-            // filePrefix에 맞는 파일명을 가져온다.
-            String prevFileName = filePrefix.getPdfFileName(resident);
-            // 파일명을 filePrefix를 단서로 하여(입사신청, 퇴사신청서) Resident에 저장한다.
-            filePrefix.setPdfFileNameToResident(resident, uploadedFilename);
+            String prevFilename = residentFileManager.getPdfFilename(resident, filePrefix);
+            residentFileManager.setPdfFilenameToResident(resident, filePrefix, uploadedFilename);
 
             res.addToDtoList(filename, "OK", null);
             res.addSuccessCount();
 
-            if (prevFileName != null)
-                fileService.deleteFile(filePrefix, prevFileName);
+            if (prevFilename != null)
+                fileService.deleteFile(filePrefix, prevFilename);
         }
         // 한 건도 업로드하지 못했으면 예외발생
         if (res.getSuccessCount() == 0)
@@ -149,7 +148,7 @@ public class ResidentService {
         Room room = roomService.getByAssignedRoom(reqDto.getAssignedRoom());
         Resident resident = reqDto.toEntity(room);
 
-       save(resident);
+        save(resident);
     }
 
     @Transactional

--- a/src/main/java/com/dominest/dominestbackend/global/util/ExcelUtil.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/ExcelUtil.java
@@ -113,7 +113,7 @@ public class ExcelUtil {
     }
 
     // 통과차수별 방 정보와 소속된 사생의 정보를 반환.
-    public static void createAndRespondCheckedRoomData(String filename, String sheetName, HttpServletResponse response, List<CheckedRoom> checkedRooms) {
+    public static void createAndRespondResidentInfoWithCheckedRoom(String filename, String sheetName, HttpServletResponse response, List<CheckedRoom> checkedRooms) {
         if (! isExcelExt(filename)) {
             throw new AppServiceException(ErrorCode.INVALID_FILE_EXTENSION);
         }
@@ -167,7 +167,7 @@ public class ExcelUtil {
     }
 
     // 점검표 화면의 내용 전체를 다운로드
-    public static void createAndRespondAllCheckedRoomData(String filename, String sheetName, HttpServletResponse response, List<CheckedRoom> checkedRooms) {
+    public static void createAndRespondAllDataWithCheckedRoom(String filename, String sheetName, HttpServletResponse response, List<CheckedRoom> checkedRooms) {
         if (! isExcelExt(filename)) {
             throw new AppServiceException(ErrorCode.INVALID_FILE_EXTENSION);
         }
@@ -246,8 +246,8 @@ public class ExcelUtil {
         }
     }
 
-    // 통과차수별 방 정보와 소속된 사생의 정보를 반환.
-    public static void createAndRespondComplaintData(String filename, String sheetName, HttpServletResponse response, List<Complaint> complaints) {
+    // 민원처리내역의 모든 데이터를 엑셀로 반환한다.
+    public static void createAndRespondAllDataWitehComplaint(String filename, String sheetName, HttpServletResponse response, List<Complaint> complaints) {
         if (! isExcelExt(filename)) {
             throw new AppServiceException(ErrorCode.INVALID_FILE_EXTENSION);
         }

--- a/src/main/java/com/dominest/dominestbackend/global/util/ExcelUtil.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/ExcelUtil.java
@@ -61,7 +61,7 @@ public class ExcelUtil {
                 List<String> rowData = new ArrayList<>(RESIDENT_COLUMN_COUNT); // default capacity 10이므로 컬럼개수만큼 공간 확보
                 while (cellIterator.hasNext()) {
                     Cell cell = cellIterator.next();
-                    String cellValue = "";
+                    String cellValue;
                     switch (cell.getCellType()) {
                         case STRING:
                             cellValue = cell.getStringCellValue();

--- a/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
@@ -11,9 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +47,7 @@ public class FileService {
             return null;
         }
         String originalFileName = multipartFile.getOriginalFilename();
-        String storedFileName = createStoredFilePath(originalFileName);
+        String storedFileName = convertFileNameToUuid(originalFileName);
         Path storedFilePath = Paths.get(fileUploadPath + prefix.getPrefix() + storedFileName);
 
         try {
@@ -63,7 +61,7 @@ public class FileService {
         return storedFileName;
     }
 
-    private String createStoredFilePath(String originalFileName) {
+    private String convertFileNameToUuid(String originalFileName) {
         String uuid = UUID.randomUUID().toString();
         String ext = extractExt(originalFileName);
 

--- a/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
@@ -152,7 +152,8 @@ public class FileService {
     }
     @RequiredArgsConstructor
     public enum FileExt {
-        PDF("pdf");
+        PDF("pdf"),
+        XLSX("xlsx");
 
         public final String value;
     }

--- a/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
@@ -1,14 +1,11 @@
 package com.dominest.dominestbackend.global.util;
 
-import com.dominest.dominestbackend.domain.resident.Resident;
 import com.dominest.dominestbackend.global.exception.ErrorCode;
-import com.dominest.dominestbackend.global.exception.exceptions.BusinessException;
 import com.dominest.dominestbackend.global.exception.exceptions.file.FileIOException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -151,26 +148,6 @@ public class FileService {
 
         FilePrefix(String prefix) {
             this.prefix = prefix;
-        }
-
-        public String getPdfFileName(Resident resident) {
-            if (this.equals(RESIDENT_ADMISSION)) {
-                return resident.getAdmissionPdfFileName();
-            } else if (this.equals(RESIDENT_DEPARTURE)) {
-                return resident.getDeparturePdfFileName();
-            } else {
-                return null;
-            }
-        }
-
-        public void setPdfFileNameToResident(Resident resident, String uploadedFileName) {
-            if (this.equals(RESIDENT_ADMISSION)) {
-                resident.setAdmissionPdfFileName(uploadedFileName);
-            } else if (this.equals(RESIDENT_DEPARTURE)) {
-                resident.setDeparturePdfFileName(uploadedFileName);
-            } else { // 입사신청서, 퇴사신청서가 아닌 다른 FilePrefix 값일 때
-                throw new BusinessException("잘못된 FilePrefix 값입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-            }
         }
     }
     @RequiredArgsConstructor

--- a/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
+++ b/src/main/java/com/dominest/dominestbackend/global/util/FileService.java
@@ -132,6 +132,11 @@ public class FileService {
         fileNames.forEach(fileName -> deleteFile(filePrefix, fileName));
     }
 
+    public boolean isInvalidFileExtension(String fileName, FileExt fileExt) {
+        String ext = extractExt(fileName);
+        return !ext.equals(fileExt.value);
+    }
+
     // fileUploadPath 내부에 저장될 directory 를 선택한다.
     // fileUplaodPath + FilePrefix + fileName 으로 저장된다.
     @Getter


### PR DESCRIPTION
## 요약
- 민원처리내역 엑셀 다운로드기능
- 리팩토링, 리네임 작업 (주로 FileService 관련)

## 추가사항
- 엑셀 다운로드 API [GET] "/categories/{categoryId}/posts/complaint/xlsx?downloadCnt=100"
  - 최근 {downloadCnt}건의 민원내역만큼만 다운로드된다.
    - 파일명: 23-11-19 민원접수내역 최신 {downloadCnt}건.xlsx
  - downloadCnt 쿼리 파라미터 생략 시 전체 다운로드된다.
    - 파일명: 23-11-19 민원접수내역 전체 {count * from Complaint Where category_id = id}건.xlsx

## 수정사항
- **버그 수정**: 입퇴사신청서 PDF파일 저장 시, DB상에는 파일명이 {사생이름}-UUID.pdf로 저장되지만 실제 파일명은 UUID.pdf인 문제 해결
  - 이 과정에서 FileService의 `save(prefix, file, filename) 메서드 추가.` 저장할 파일명을 외부에서 주입받아 그대로 저장함.
- **변수명 변경**: FileService에서 '저장될 파일명'을 의미하는 변수명이 `storedFilename` 이었음.
  의미상 `'저장된 파일명' 이 아닌 '저장된 파일명'` 이므로 `filenameToStore` 로 변경.
- **클래스 책임 이동**: FilePrefix의 메서드를 호출해서 Resident 객체의 값을 가져오거나 변경할 수 있었던 모호한 책임 문제를
  ResidentFileManager가 하도록 변경
- **클래스 추가**: FileService의 하위 enum 클래스인 FileExt를 생성하고, 파일 확장자를 검사하거나 지정하는 데 사용함.
 



리팩토링 작업이 많은데 
생각해보니까 리팩토링 브랜치를 만들고 거기서 작업하는게 나았을거같음
하지만 작업중에도 보이는
과거에 내가 싸놓은 이상한 코드들 
즉시 수정 참는거 쉽지않음...